### PR TITLE
[codex] fix security workflow permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,17 +15,14 @@ concurrency:
   group: security-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.96.0
-  BINARY_NAME: openai_rust_sdk
-  SBOM_MANIFEST_PATH: Cargo.toml
-
 jobs:
   # Security audit for dependencies
   audit:
     name: Security Audit
     runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+      RUST_VERSION: 1.96.0
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       
@@ -55,6 +52,9 @@ jobs:
   license-check:
     name: License Check
     runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+      RUST_VERSION: 1.96.0
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       
@@ -114,6 +114,9 @@ jobs:
   codeql:
     name: CodeQL Analysis
     runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+      RUST_VERSION: 1.96.0
     permissions:
       security-events: write
       actions: read
@@ -171,6 +174,11 @@ jobs:
   supply-chain:
     name: Supply Chain Security
     runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+      RUST_VERSION: 1.96.0
+      BINARY_NAME: openai_rust_sdk
+      SBOM_MANIFEST_PATH: Cargo.toml
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       
@@ -237,6 +245,9 @@ jobs:
   owasp:
     name: OWASP Dependency Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       
@@ -268,6 +279,9 @@ jobs:
     name: Container Security Scan
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' || github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       


### PR DESCRIPTION
## Summary

- Removes the top-level `env` block from `security.yml` so OSSF Scorecard can verify and publish results.
- Moves Rust/SBOM environment values to the specific jobs that need them.
- Grants `security-events: write` to OWASP and container scan jobs that upload SARIF.

## Root Cause

Main failed after PR #82 because the Security workflow added global environment variables, which Scorecard rejects when publishing results, and two SARIF upload jobs only had read-level security event permissions.

## Validation

- `git diff --check`
- `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/security.yml", encoding="utf-8")); print("security.yml parses")'`
