### PR TITLE
feat: refresh OpenAI API support and latest Rust dependencies

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -13,4 +13,7 @@ ignore = [
     # Bincode unmaintained - transitive dependency through yara-x
     # yara-x has not yet migrated away from bincode; no direct fix available
     "RUSTSEC-2025-0141",
+    # wasmtime is required by yara-x 1.19.0, which has not released a version
+    # using a fixed wasmtime range yet; remove this exception when yara-x ships it.
+    "RUSTSEC-2026-0222",
 ]

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -29,7 +29,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RUST_VERSION: 1.96.0
+  RUST_VERSION: 1.97.1
 
 jobs:
   check-for-release:
@@ -45,6 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -185,6 +186,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -310,10 +312,13 @@ jobs:
           mv CHANGELOG.new.md CHANGELOG.md
       
       - name: Create and push tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ needs.check-for-release.outputs.next_version }}"
           # Tag the current HEAD directly — no push to main (branch protection blocks direct pushes)
           git tag -a "v$VERSION" -m "Release v$VERSION"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push origin "v$VERSION"
 
       - name: Create GitHub Release
@@ -329,6 +334,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create version bump PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
         run: |
           VERSION="${{ needs.check-for-release.outputs.next_version }}"
           BRANCH="chore/release-v${VERSION}"
@@ -341,6 +349,7 @@ jobs:
           - Version: ${{ needs.check-for-release.outputs.current_version }} → ${VERSION}
           - Updated CHANGELOG.md"
 
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push origin "$BRANCH"
 
           gh pr create \
@@ -371,6 +380,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 0
       
       - name: Install Rust toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   RUSTUP_MAX_RETRIES: 10
-  RUST_STABLE_VERSION: 1.96.0
+  RUST_STABLE_VERSION: 1.97.1
   # Reduce debug info and optimize for smaller binaries
   CARGO_PROFILE_TEST_DEBUG: 1
   CARGO_PROFILE_DEV_DEBUG: 1
@@ -45,6 +45,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88  # v1
@@ -95,6 +97,8 @@ jobs:
     continue-on-error: ${{ matrix.rust == 'nightly' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       
       # Free up disk space on GitHub runners
       - name: Free Disk Space (Ubuntu)
@@ -199,6 +203,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       
       - name: Install MSRV toolchain
         uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88  # v1
@@ -220,6 +226,8 @@ jobs:
     needs: quick-check
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88  # v1
@@ -264,6 +272,8 @@ jobs:
     needs: quick-check
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88  # v1
@@ -293,6 +303,8 @@ jobs:
     needs: quick-check
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88  # v1
@@ -322,6 +334,8 @@ jobs:
     if: github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'integration-test')
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88  # v1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,6 +53,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Lowercase image name
         id: lowercase
@@ -238,6 +240,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Download image (PRs)
         if: github.event_name == 'pull_request'

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -18,7 +18,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  RUST_VERSION: 1.96.0
+  RUST_VERSION: 1.97.1
 
 jobs:
   # Comprehensive linting
@@ -27,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88  # v1
@@ -75,6 +77,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88  # v1
@@ -113,6 +117,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88  # v1
@@ -153,6 +159,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88  # v1
@@ -209,6 +217,8 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88  # v1
@@ -240,6 +250,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88  # v1
@@ -294,6 +306,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88  # v1
@@ -333,6 +347,8 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Check for code duplication
         uses: platisd/duplicate-code-detection-tool@f0413b1571a98b653f617a59fec0097001e18c0e  # v1.2.0
@@ -350,6 +366,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       
       - name: Install codespell
         run: pip install codespell==2.4.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  RUST_VERSION: 1.96.0
+  RUST_VERSION: 1.97.1
   BINARY_NAME: openai_rust_sdk
   BINARY_PACKAGE: ""
   CLI_NAME: openai-rust-sdk
@@ -44,6 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Install gh CLI
@@ -157,6 +158,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88  # v1
@@ -280,6 +283,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88  # v1
@@ -315,6 +320,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4.2.0
@@ -383,6 +390,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
@@ -406,6 +415,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           ref: main
       
       - name: Install Rust toolchain

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,9 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_COLOR: always
-      RUST_VERSION: 1.96.0
+      RUST_VERSION: 1.97.1
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88  # v1
@@ -54,9 +56,11 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_COLOR: always
-      RUST_VERSION: 1.96.0
+      RUST_VERSION: 1.97.1
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88  # v1
@@ -116,13 +120,15 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_COLOR: always
-      RUST_VERSION: 1.96.0
+      RUST_VERSION: 1.97.1
     permissions:
       security-events: write
       actions: read
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       
       - name: Initialize CodeQL
         uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4
@@ -155,6 +161,8 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       
       - name: Run Semgrep
         uses: semgrep/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d  # v1.54.1
@@ -176,11 +184,13 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_COLOR: always
-      RUST_VERSION: 1.96.0
+      RUST_VERSION: 1.97.1
       BINARY_NAME: openai_rust_sdk
       SBOM_MANIFEST_PATH: Cargo.toml
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88  # v1
@@ -221,6 +231,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 0  # Fetch all history for secret scanning
       
       - name: TruffleHog OSS
@@ -250,6 +261,8 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       
       - name: Run OWASP Dependency Check
         uses: dependency-check/Dependency-Check_Action@75ba02d6183445fe0761d26e836bde58b1560600  # 1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [1.6.0] - 2026-08-01
+
+### Features
+
+- Update the Responses API for current GPT-5 reasoning, prompt-cache, truncation, personality,
+  tool, background, compaction, token-counting, and streaming-event features.
+- Add current Realtime client-secret and transcription-session endpoints.
+- Update the Videos API for current creation payloads, image references, edit, extend, remix,
+  and binary content downloads.
+- Upgrade the WebRTC stack and refresh Rust, crate, and GitHub Actions versions.
+
+### Compatibility
+
+- Preserve the legacy GPT-5 snapshot constants and video request builders as compatibility
+  surfaces while translating them to current API payloads.
+
 ## [1.5.1] - 2026-06-13
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,24 +168,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-
-[[package]]
-name = "arc-swap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
-dependencies = [
- "rustversion",
-]
 
 [[package]]
 name = "ascii_tree"
@@ -221,7 +212,7 @@ dependencies = [
  "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
 ]
 
@@ -233,7 +224,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -245,7 +236,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -257,7 +248,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -268,6 +259,30 @@ checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -310,18 +325,18 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -338,9 +353,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -348,14 +363,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -369,6 +385,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
 
 [[package]]
 name = "base64ct"
@@ -408,7 +430,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -418,6 +440,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,18 +456,18 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
@@ -480,13 +511,13 @@ checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
 dependencies = [
  "memchr",
  "regex-automata",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -518,7 +549,7 @@ checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -559,9 +590,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -589,9 +620,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -606,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -682,9 +713,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -692,9 +723,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -704,14 +735,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -735,7 +766,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -750,7 +781,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -905,7 +936,7 @@ dependencies = [
  "log",
  "pulley-interpreter",
  "regalloc2",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
  "serde",
  "smallvec",
  "target-lexicon",
@@ -1003,6 +1034,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1048,9 +1088,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1067,9 +1107,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -1141,14 +1181,14 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "daachorse"
-version = "3.0.0"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d87f75bbe32ee10609201e09e818537df81c3acb436be2b78f47cc85d139475"
+checksum = "5614204febbc33cc07a2806aa6440b904ac012b68eecc37f4493ea4a76455a3d"
 
 [[package]]
 name = "darling"
@@ -1170,7 +1210,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1181,7 +1221,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1252,9 +1292,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "diff"
@@ -1287,13 +1324,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1310,42 +1347,6 @@ dependencies = [
  "sha2",
  "signature",
  "zeroize",
-]
-
-[[package]]
-name = "dtls"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f016db07b91e9d79cc60a152c163d3f0ce2d4c0173cb3964de3526aab6e07fa"
-dependencies = [
- "aes",
- "aes-gcm",
- "async-trait",
- "bytecheck",
- "byteorder",
- "cbc",
- "ccm",
- "chacha20poly1305",
- "der-parser 9.0.0",
- "hmac",
- "log",
- "p256",
- "p384",
- "portable-atomic",
- "rand 0.9.4",
- "rand_core 0.6.4",
- "rcgen",
- "ring",
- "rkyv",
- "rustls",
- "sec1",
- "sha1 0.10.6",
- "sha2",
- "thiserror 1.0.69",
- "tokio",
- "webrtc-util",
- "x25519-dalek",
- "x509-parser 0.16.0",
 ]
 
 [[package]]
@@ -1370,9 +1371,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "elliptic-curve"
@@ -1429,16 +1430,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -1483,9 +1483,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ff"
@@ -1515,6 +1515,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
+ "crc32fast",
  "miniz_oxide",
  "zlib-rs",
 ]
@@ -1535,12 +1536,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -1581,9 +1576,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1596,9 +1591,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1606,15 +1601,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1623,32 +1618,32 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-timer"
@@ -1658,9 +1653,9 @@ checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1713,16 +1708,16 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1760,9 +1755,9 @@ dependencies = [
 
 [[package]]
 name = "globset"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -1777,7 +1772,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "ignore",
  "walkdir",
 ]
@@ -1795,9 +1790,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1831,20 +1826,11 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "foldhash 0.2.0",
+ "foldhash",
  "serde",
  "serde_core",
 ]
@@ -1857,7 +1843,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -1866,13 +1852,13 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "headers-core",
  "http",
  "httpdate",
  "mime",
- "sha1 0.10.6",
+ "sha1 0.10.7",
 ]
 
 [[package]]
@@ -1931,9 +1917,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1941,9 +1927,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -1951,9 +1937,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1983,7 +1969,7 @@ dependencies = [
  "assert-json-diff",
  "async-object-pool",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "crossbeam-utils",
  "form_urlencoded",
@@ -2002,7 +1988,7 @@ dependencies = [
  "similar",
  "stringmetrics",
  "tabwriter",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "url",
@@ -2010,18 +1996,18 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2060,7 +2046,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2071,7 +2057,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2218,9 +2204,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.25"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+checksum = "7f8a7b8211e695a1d0cd91cace480d4d0bd57667ab10277cc412c5f7f4884f83"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -2259,27 +2245,6 @@ name = "intaglio"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eca9188c1b20836bb561bc09bb2f54e9ca99b271031b5f3ff183a00c08c98c8"
-
-[[package]]
-name = "interceptor"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f73f4fdb971cab2d599cbdc2ccf0c6ea8fb27347b871ed14c65ce2353dbe75b"
-dependencies = [
- "async-trait",
- "bytes",
- "futures",
- "log",
- "portable-atomic",
- "rand 0.9.4",
- "rtcp",
- "rtp",
- "thiserror 1.0.69",
- "tokio",
- "waitgroup",
- "webrtc-srtp",
- "webrtc-util",
-]
 
 [[package]]
 name = "inventory"
@@ -2338,7 +2303,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "walkdir",
  "windows-link",
 ]
@@ -2353,7 +2318,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2372,36 +2337,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "jsonschema"
-version = "0.47.0"
+version = "0.49.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "281c43ff06dcb331e9356d30e38853d559ce3d0a3f693e0b0e102667dec14fb1"
+checksum = "f8a77951c56b6a0af03c22af6953d6ffcfba9403c765578921f3f1089b999db6"
 dependencies = [
  "ahash",
  "bytecount",
@@ -2413,6 +2377,7 @@ dependencies = [
  "idna",
  "itoa",
  "jsonschema-regex",
+ "jsonschema-value",
  "num-cmp",
  "num-traits",
  "percent-encoding",
@@ -2422,17 +2387,32 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "strum",
  "unicode-general-category",
  "uuid-simd",
 ]
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.47.0"
+version = "0.49.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee0b351864e7ffbc5db9273daf7fa1b4d5177b0946713d667ca571b83c0b4045"
+checksum = "a4c2e64f341a1d6a15d2daa3c967e48921cf15b9c7f23a9899e8b63c7f7c4199"
 dependencies = [
  "regex-syntax",
+]
+
+[[package]]
+name = "jsonschema-value"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e097778f3e9c6a33862077dbf07aca0360d0b18d2a7abc323da132df49ee83"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "fraction",
+ "num-cmp",
+ "num-traits",
+ "serde_json",
 ]
 
 [[package]]
@@ -2461,9 +2441,9 @@ dependencies = [
 
 [[package]]
 name = "leb128"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cc46bac87ef8093eed6f272babb833b6443374399985ac8ed28471ee0918545"
+checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
 
 [[package]]
 name = "leb128fmt"
@@ -2473,9 +2453,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -2538,7 +2518,7 @@ dependencies = [
  "quote",
  "regex-syntax",
  "rustc_version",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2586,9 +2566,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memfd"
@@ -2657,9 +2637,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -2683,7 +2663,7 @@ dependencies = [
  "hyper-util",
  "log",
  "pin-project-lite",
- "rand 0.9.4",
+ "rand 0.9.5",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -2708,7 +2688,7 @@ checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2759,9 +2739,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -2778,7 +2758,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
  "smallvec",
  "zeroize",
 ]
@@ -2812,7 +2792,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2826,11 +2806,10 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -2922,11 +2901,12 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openai_rust_sdk"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "async-stream",
- "base64",
+ "async-trait",
+ "base64 0.23.0",
  "bytes",
  "chrono",
  "clap",
@@ -2943,10 +2923,11 @@ dependencies = [
  "qlora-paste",
  "rand 0.10.2",
  "reqwest",
+ "rtc",
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tokio-test",
@@ -3048,7 +3029,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -3099,6 +3080,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plotters"
@@ -3152,12 +3139,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
 name = "postcard"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3204,16 +3185,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3224,9 +3195,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -3284,9 +3255,9 @@ dependencies = [
 
 [[package]]
 name = "psl"
-version = "2.1.210"
+version = "2.1.223"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27fbd4d9b2eb0b6e0cbd654bce70243f460cbc8dc92df6747e3fb911ce1cd4a8"
+checksum = "c0dedad316e05de220cbf3fd8bfb69f3df8755dde2d7d479211827b595168a93"
 dependencies = [
  "psl-types",
 ]
@@ -3314,7 +3285,7 @@ checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3337,30 +3308,30 @@ checksum = "36f7d5ef31ebf1b46cd7e722ffef934e670d7e462f49aa01cde07b9b76dca580"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "qlora-paste"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa4ab9c7f8287fce458ee9be80596b25c0aa5b2c8a08eea564e2c58d7ecef52"
+checksum = "bf21d1ddc7276020b2ae5098bd6a28724ae16efd019a76e46a118afdc963d2dc"
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
  "pin-project-lite",
  "quinn-proto",
- "quinn-udp",
- "rustc-hash 2.1.2",
+ "quinn-udp 0.5.15",
+ "rustc-hash 2.1.3",
  "rustls",
- "socket2 0.5.10",
- "thiserror 2.0.18",
+ "socket2",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "web-time",
@@ -3368,21 +3339,22 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3390,23 +3362,36 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76150b617afc75e6e21ac5f39bc196e80b65415ae48d62dbef8e2519d040ce42"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "log",
+ "socket2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -3431,18 +3416,18 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rancor"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
+checksum = "daff8b7b3ccf5f7ba270b3e7a0a4d4c701c5797e38dec27c7e2c3dbb830fed1c"
 dependencies = [
  "ptr_meta",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
@@ -3450,9 +3435,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3464,8 +3449,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20 0.10.0",
- "getrandom 0.4.2",
+ "chacha20 0.10.1",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -3514,6 +3499,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3535,15 +3529,15 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.13.2"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
 dependencies = [
  "pem",
  "ring",
  "rustls-pki-types",
  "time",
- "x509-parser 0.16.0",
+ "x509-parser 0.18.1",
  "yasna",
 ]
 
@@ -3553,34 +3547,34 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "referencing"
-version = "0.47.0"
+version = "0.49.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348e860aeb0b7bd035778fd11dd9cd5290d32e4aed3b8f2274a00287a9fd362b"
+checksum = "b772e96f8eb6badd4eb10fbc08b8a98244c09b4af37e72e8fa612c854604b870"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -3595,23 +3589,23 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
+checksum = "757712e8e61590d6d4f5d563483755538b5aa13467837a3b41cd9832509a7f85"
 dependencies = [
  "allocator-api2",
  "bumpalo",
  "hashbrown 0.17.1",
  "log",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
  "smallvec",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3621,9 +3615,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3632,15 +3626,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rend"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
+checksum = "663ba70707f96e871406fe10d68128412e619b06d1d47cb91c3a4c6501176240"
 dependencies = [
  "bytecheck",
 ]
@@ -3651,7 +3645,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -3714,9 +3708,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
+checksum = "815cc8a37159a463064825246cadb07961e25cd9885908606f6d08a98d8f8874"
 dependencies = [
  "bytecheck",
  "bytes",
@@ -3733,13 +3727,13 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
+checksum = "c0ed1a78a1b19d184b0daa629dd9a024573173ec7d485b287cb369fb3607cc1c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3784,29 +3778,279 @@ dependencies = [
 ]
 
 [[package]]
-name = "rtcp"
-version = "0.17.1"
+name = "rtc"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb22f1cc99aea8152fdae6a4bc52a9caddf4bd1ff083d897c1f9f279956177e8"
+checksum = "ce487200429491d9295789a6dd5ce16f56c4715373c97164df9f544a220c8c64"
 dependencies = [
  "bytes",
- "thiserror 1.0.69",
- "webrtc-util",
+ "hex",
+ "log",
+ "rand 0.10.2",
+ "rcgen",
+ "ring",
+ "rtc-datachannel",
+ "rtc-dtls",
+ "rtc-ice",
+ "rtc-interceptor",
+ "rtc-mdns",
+ "rtc-media",
+ "rtc-rtcp",
+ "rtc-rtp",
+ "rtc-sctp",
+ "rtc-sdp",
+ "rtc-shared",
+ "rtc-srtp",
+ "rtc-stun",
+ "rtc-turn",
+ "rustls",
+ "sansio",
+ "serde",
+ "serde_json",
+ "sha2",
+ "unicase",
+ "url",
 ]
 
 [[package]]
-name = "rtp"
-version = "0.17.1"
+name = "rtc-datachannel"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8d41f3565d9add11caabe7c61745517f4ef511c168a6aa2b59ce4c701802cde"
+checksum = "bf1815e5d40058b8eb0ed79e89414ecbda1da74a848d741c68e4de5d66aed9c1"
+dependencies = [
+ "bytes",
+ "log",
+ "rtc-sctp",
+ "rtc-shared",
+ "sansio",
+]
+
+[[package]]
+name = "rtc-dtls"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473e1837315631df4e0aafdf08b0386c77aaa8b1632bd7484bdd3bf7ded65b19"
+dependencies = [
+ "aes",
+ "bytecheck",
+ "byteorder",
+ "bytes",
+ "cbc",
+ "ccm",
+ "chacha20poly1305",
+ "der-parser 9.0.0",
+ "hmac",
+ "log",
+ "p256",
+ "p384",
+ "rand 0.10.2",
+ "rand_core 0.6.4",
+ "rcgen",
+ "ring",
+ "rkyv",
+ "rtc-shared",
+ "rustls",
+ "sec1",
+ "sha1 0.10.7",
+ "sha2",
+ "subtle",
+ "x25519-dalek",
+ "x509-parser 0.16.0",
+]
+
+[[package]]
+name = "rtc-ice"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cbf161bce9556df68a9c2dd781d9cecbb8de09a3acba5655b5a4f6ad80aa06c"
+dependencies = [
+ "bytes",
+ "crc",
+ "log",
+ "rand 0.10.2",
+ "rtc-mdns",
+ "rtc-shared",
+ "rtc-stun",
+ "sansio",
+ "serde",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "rtc-interceptor"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16672ca0665d05be30a8d51e539df18afe15491b5bf29ed644791d053575a96"
+dependencies = [
+ "log",
+ "rand 0.10.2",
+ "rtc-interceptor-derive",
+ "rtc-rtcp",
+ "rtc-rtp",
+ "rtc-shared",
+ "sansio",
+]
+
+[[package]]
+name = "rtc-interceptor-derive"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d50521cd5a26f7e829a5bf6ade44c3bec6855716fa7a0f6141b413c186d185d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "rtc-mdns"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cba0f67ae11d0820c2ce589dd134a6618f3eddcbb1b53ba2f2b56d64da02ac"
+dependencies = [
+ "bytes",
+ "log",
+ "rtc-shared",
+ "sansio",
+ "socket2",
+]
+
+[[package]]
+name = "rtc-media"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0842037bf13bf9effbe5c2ca1815e9a977db79becc859deb2d43239d606a1935"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "rand 0.10.2",
+ "rtc-rtp",
+ "rtc-shared",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "rtc-rtcp"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c46297e46a9aeb640001c73bcfc3df1831cb98bd3a93cd98543d188600af825e"
+dependencies = [
+ "bytes",
+ "rtc-shared",
+]
+
+[[package]]
+name = "rtc-rtp"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e5180eabadb76b7bb95c3341fa25232279733fbc9db7665e2abb9aaf6ea7556"
 dependencies = [
  "bytes",
  "memchr",
- "portable-atomic",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rtc-shared",
  "serde",
- "thiserror 1.0.69",
- "webrtc-util",
+]
+
+[[package]]
+name = "rtc-sctp"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85fff50f44bea4e5c37f9cd72cbe2d746beb62b111c2d4d9443ac3c5dd19d846"
+dependencies = [
+ "bytes",
+ "crc32c",
+ "log",
+ "rand 0.10.2",
+ "rtc-shared",
+ "rustc-hash 2.1.3",
+ "slab",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "rtc-sdp"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ef2bf0bc026bf4c524dc857c65b2c646425e810db33c2bb74fe85e121794786"
+dependencies = [
+ "rand 0.10.2",
+ "rtc-shared",
+ "url",
+]
+
+[[package]]
+name = "rtc-shared"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "542a2b3c560ba295f883fceba918a4f796d3f270b55679162308fa99b900d45f"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "bitflags 1.3.2",
+ "bytes",
+ "nix",
+ "p256",
+ "rand 0.10.2",
+ "rcgen",
+ "sec1",
+ "serde",
+ "substring",
+ "thiserror 2.0.19",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "rtc-srtp"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33666140469dd1e9effd093824a8aa66ac4c753ad1c9f0123c4acc9b8840c4c8"
+dependencies = [
+ "aes",
+ "byteorder",
+ "bytes",
+ "ctr",
+ "hmac",
+ "ring",
+ "rtc-rtcp",
+ "rtc-rtp",
+ "rtc-shared",
+ "sha1 0.10.7",
+ "subtle",
+]
+
+[[package]]
+name = "rtc-stun"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e84f06c69299b98f9fc271dda4b628d3f1694375061b8af1145b47a7e25f05"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "crc",
+ "lazy_static",
+ "md-5",
+ "rand 0.10.2",
+ "ring",
+ "rtc-shared",
+ "sansio",
+ "subtle",
+ "url",
+]
+
+[[package]]
+name = "rtc-turn"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6169b99a62428c832423613aadc460d32edb792afd216bde95670d28443bf527"
+dependencies = [
+ "bytes",
+ "log",
+ "rtc-shared",
+ "rtc-stun",
+ "sansio",
 ]
 
 [[package]]
@@ -3817,9 +4061,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -3845,11 +4089,11 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3858,18 +4102,18 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -3882,9 +4126,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -3894,9 +4138,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3920,7 +4164,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3943,9 +4187,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -3963,6 +4207,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sansio"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62751faa8bc286982334a082fe125184a29fc89d17775766e4f891b7d726980"
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3976,18 +4226,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sdp"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22c3b0257608d7de4de4c4ea650ccc2e6e3e45e3cd80039fcdee768bcb449253"
-dependencies = [
- "rand 0.9.4",
- "substring",
- "thiserror 1.0.69",
- "url",
-]
 
 [[package]]
 name = "sec1"
@@ -4009,7 +4247,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -4034,9 +4272,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -4044,29 +4282,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "indexmap",
  "itoa",
@@ -4078,9 +4316,9 @@ dependencies = [
 
 [[package]]
 name = "serde_regex"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+checksum = "bafc8d0c5330cecff10f16b459b479fd9acaa5b4acd7167301414e21b0057012"
 dependencies = [
  "regex",
  "serde",
@@ -4100,9 +4338,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -4133,9 +4371,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -4159,15 +4397,15 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -4193,37 +4431,18 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "smol_str"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -4231,9 +4450,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spki"
@@ -4264,6 +4483,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4272,26 +4500,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "stun"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0fd33c04d4617df42c9c84c698511c59f59869629fb7a193067eec41bce347"
-dependencies = [
- "base64",
- "crc",
- "lazy_static",
- "md-5",
- "rand 0.9.4",
- "ring",
- "subtle",
- "thiserror 1.0.69",
- "tokio",
- "url",
- "webrtc-util",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4311,9 +4520,20 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4337,7 +4557,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4368,10 +4588,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4400,11 +4620,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -4415,28 +4635,27 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -4446,15 +4665,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4482,9 +4701,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4496,10 +4715,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "tokio"
-version = "1.52.3"
+name = "tinyzip"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "6847a2bf223d67c916a25d5fb8d197fc1c7c3205421e05d50f3373e092034146"
+
+[[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -4507,20 +4732,20 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4535,9 +4760,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -4569,13 +4794,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -4601,7 +4827,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http",
@@ -4645,7 +4871,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4676,28 +4902,7 @@ dependencies = [
  "log",
  "rand 0.10.2",
  "sha1 0.11.0",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "turn"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a8b8ac3543b2a8eb0b28c7ac3d5f2db6221e057f3b3ae47cf7637b1333a5c3"
-dependencies = [
- "async-trait",
- "base64",
- "futures",
- "log",
- "md-5",
- "portable-atomic",
- "rand 0.9.4",
- "ring",
- "stun",
- "thiserror 1.0.69",
- "tokio",
- "tokio-util",
- "webrtc-util",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4708,9 +4913,9 @@ checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicase"
@@ -4790,11 +4995,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.5"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -4828,15 +5033,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
-name = "waitgroup"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1f50000a783467e6c0200f9d10642f4bc424e39efc1b770203e88b488f79292"
-dependencies = [
- "atomic-waker",
-]
-
-[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4848,9 +5044,9 @@ dependencies = [
 
 [[package]]
 name = "walrus"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fdd11e7cc2c5c875228bb82c1b41ff1444ab2c3aed74e9e4c845652b0349302"
+checksum = "3bfa49767bb3a9e1afb02aa95bbcbde8d82f2db4ca377afae94d688f14f62378"
 dependencies = [
  "anyhow",
  "gimli 0.32.3",
@@ -4858,8 +5054,8 @@ dependencies = [
  "leb128",
  "log",
  "walrus-macro",
- "wasm-encoder 0.245.1",
- "wasmparser 0.245.1",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -4871,7 +5067,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4891,27 +5087,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4922,9 +5109,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4932,9 +5119,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4942,34 +5129,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -4979,19 +5156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.245.1",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder 0.244.0",
- "wasmparser 0.244.0",
+ "wasmparser",
 ]
 
 [[package]]
@@ -5009,23 +5174,11 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.13.0",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.245.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "hashbrown 0.16.1",
  "indexmap",
  "semver",
@@ -5040,7 +5193,7 @@ checksum = "5f41517a3716fbb8ccf46daa9c1325f760fcbff5168e75c7392288e410b91ac8"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.245.1",
+ "wasmparser",
 ]
 
 [[package]]
@@ -5051,7 +5204,7 @@ checksum = "efb1ed5899dde98357cfdcf647a4614498798719793898245b4b34e663addabf"
 dependencies = [
  "addr2line",
  "async-trait",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bumpalo",
  "cc",
  "cfg-if",
@@ -5068,7 +5221,7 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.245.1",
+ "wasmparser",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-cranelift",
@@ -5101,8 +5254,8 @@ dependencies = [
  "sha2",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.245.1",
- "wasmparser 0.245.1",
+ "wasm-encoder",
+ "wasmparser",
  "wasmprinter",
  "wasmtime-internal-core",
 ]
@@ -5137,8 +5290,8 @@ dependencies = [
  "pulley-interpreter",
  "smallvec",
  "target-lexicon",
- "thiserror 2.0.18",
- "wasmparser 0.245.1",
+ "thiserror 2.0.19",
+ "wasmparser",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-unwinder",
@@ -5203,14 +5356,14 @@ checksum = "737c4d956fc3a848541a064afb683dd2771132a6b125be5baaf95c4379aa47df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5228,180 +5381,29 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webrtc"
-version = "0.17.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba06986c4fcfbbb4b490abe4b88887b0ac9de0d3eb0aae36f3254e38d6ecdd1"
+checksum = "530c3a4621c0a7a6559eae25f34ee7a430e78ecf4a6bfece1fc43a5b71985193"
 dependencies = [
- "arc-swap",
+ "async-broadcast",
+ "async-channel",
  "async-trait",
  "bytes",
- "dtls",
- "hex",
- "interceptor",
- "lazy_static",
+ "event-listener",
+ "futures",
  "log",
- "portable-atomic",
- "rand 0.9.4",
- "rcgen",
- "regex",
- "ring",
- "rtcp",
- "rtp",
- "sdp",
- "serde",
- "serde_json",
- "sha2",
- "smol_str",
- "stun",
- "thiserror 1.0.69",
+ "quinn-udp 0.6.1",
+ "rtc",
  "tokio",
- "turn",
- "unicase",
- "url",
- "waitgroup",
- "webrtc-data",
- "webrtc-ice",
- "webrtc-mdns",
- "webrtc-media",
- "webrtc-sctp",
- "webrtc-srtp",
- "webrtc-util",
-]
-
-[[package]]
-name = "webrtc-data"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ca42127ee64bcb71da36d151e6f87b12488c5f14c4f379e73d2d52a8e54aa0"
-dependencies = [
- "bytes",
- "log",
- "portable-atomic",
- "thiserror 1.0.69",
- "tokio",
- "webrtc-sctp",
- "webrtc-util",
-]
-
-[[package]]
-name = "webrtc-ice"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ede72a36e5dda685814c389b2b34ac60b3ed000a81789e93626e27180eb785"
-dependencies = [
- "arc-swap",
- "async-trait",
- "crc",
- "log",
- "portable-atomic",
- "rand 0.9.4",
- "serde",
- "serde_json",
- "stun",
- "thiserror 1.0.69",
- "tokio",
- "turn",
- "url",
- "uuid",
- "waitgroup",
- "webrtc-mdns",
- "webrtc-util",
-]
-
-[[package]]
-name = "webrtc-mdns"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b62bc8d3fb5024bc6ffde5f4aad2127ce17f8359dbc6f70208a324a12e44677"
-dependencies = [
- "log",
- "socket2 0.5.10",
- "thiserror 1.0.69",
- "tokio",
- "webrtc-util",
-]
-
-[[package]]
-name = "webrtc-media"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a28290bd0cdda196f8bf5c6f7dddaef18cc913ee0702cd1ea237bad203e337"
-dependencies = [
- "byteorder",
- "bytes",
- "rand 0.9.4",
- "rtp",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "webrtc-sctp"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ea6633bf951b3fd71eba3244731c8d0814f6a80300620a4370cad2983a5a42f"
-dependencies = [
- "arc-swap",
- "async-trait",
- "bytes",
- "crc",
- "log",
- "portable-atomic",
- "rand 0.9.4",
- "thiserror 1.0.69",
- "tokio",
- "webrtc-util",
-]
-
-[[package]]
-name = "webrtc-srtp"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e437f74b04f42049192e25cbb33c21c86be308875e6afe14cf8e28d1ffa35ac"
-dependencies = [
- "aead",
- "aes",
- "aes-gcm",
- "byteorder",
- "bytes",
- "ctr",
- "hmac",
- "log",
- "rtcp",
- "rtp",
- "sha1 0.10.6",
- "subtle",
- "thiserror 1.0.69",
- "tokio",
- "webrtc-util",
-]
-
-[[package]]
-name = "webrtc-util"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65c1e0143a43d40f69e1d8c2ffc8734e379b49c06d45892ea4104c388bf9ead"
-dependencies = [
- "async-trait",
- "bitflags 1.3.2",
- "bytes",
- "ipnet",
- "lazy_static",
- "log",
- "nix",
- "portable-atomic",
- "rand 0.9.4",
- "thiserror 1.0.69",
- "tokio",
- "winapi",
 ]
 
 [[package]]
@@ -5438,7 +5440,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5468,7 +5470,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5479,7 +5481,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5511,6 +5513,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]
@@ -5595,7 +5606,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
 dependencies = [
  "assert-json-diff",
- "base64",
+ "base64 0.22.1",
  "deadpool",
  "futures",
  "http",
@@ -5613,97 +5624,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.13.0",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder 0.244.0",
- "wasm-metadata",
- "wasmparser 0.244.0",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.244.0",
-]
 
 [[package]]
 name = "writeable"
@@ -5744,7 +5667,6 @@ dependencies = [
  "lazy_static",
  "nom 7.1.3",
  "oid-registry 0.7.1",
- "ring",
  "rusticata-macros",
  "thiserror 1.0.69",
  "time",
@@ -5762,8 +5684,9 @@ dependencies = [
  "lazy_static",
  "nom 7.1.3",
  "oid-registry 0.8.1",
+ "ring",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
 ]
 
@@ -5775,15 +5698,15 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yara-x"
-version = "1.17.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b53bd070da0bb85da8d91d943ef34536092567ce340b38f487f04017f202c9d6"
+checksum = "dd44924487d4d3d0bc42683fbfa35036406483f7fc455d820fff8f2f6b3507bd"
 dependencies = [
  "annotate-snippets",
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "bincode",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bitvec",
  "bstr",
  "const-oid 0.9.6",
@@ -5793,6 +5716,7 @@ dependencies = [
  "digest 0.10.7",
  "dsa",
  "ecdsa",
+ "flate2",
  "getrandom 0.2.17",
  "globwalk",
  "hex",
@@ -5820,16 +5744,17 @@ dependencies = [
  "regex-syntax",
  "roxmltree",
  "rsa",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
  "serde",
  "serde_json",
- "sha1 0.10.6",
+ "sha1 0.10.7",
  "sha2",
  "simd-adler32",
  "simd_cesu8",
  "smallvec",
  "strum_macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
+ "tinyzip",
  "uuid",
  "walrus",
  "wasm-bindgen",
@@ -5843,41 +5768,41 @@ dependencies = [
 
 [[package]]
 name = "yara-x-macros"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3ed838cfc6391f383db4b408ae65f0b113277222b6bb98a3baa29b5f34e3293"
+checksum = "c77caafb677e73e130c13425863c49828c2206c29e8da6aa8fb08b89b3594bef"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "yara-x-parser"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ee3856f10d3f683e76cbc4361176326caaf627a7a892520079c9defbb26c28"
+checksum = "c5564d72253142774903eafc8f4c92bebef40d65c176a11d351258e80cc8a1c7"
 dependencies = [
  "ascii_tree",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bstr",
  "indexmap",
  "itertools 0.14.0",
  "logos",
  "num-traits",
  "rowan",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
  "serde",
 ]
 
 [[package]]
 name = "yara-x-proto"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca09c91e779d5c7ae2b384cc7761b10593e327c9f953d9789608eeca6d491c80"
+checksum = "01022f120b79da81aa097fa77d281b5edeebbdfef715b239e569abebe04a241d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "itertools 0.14.0",
  "protobuf",
@@ -5887,18 +5812,19 @@ dependencies = [
 
 [[package]]
 name = "yasna"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
 dependencies = [
+ "bit-vec 0.9.1",
  "time",
 ]
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -5913,28 +5839,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5954,28 +5880,28 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6008,7 +5934,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6027,15 +5953,15 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "openai_rust_sdk"
-version = "1.5.1"
+version = "1.6.0"
 edition = "2024"
-rust-version = "1.96.0"
+rust-version = "1.97.1"
 description = "Comprehensive OpenAI API SDK for Rust with YARA rule validation"
 license = "MIT"
 repository = "https://github.com/threatflux/openai_rust_sdk"
@@ -11,35 +11,37 @@ categories = ["development-tools", "api-bindings"]
 authors = ["Wyatt Roersma", "Claude Code"]
 
 [dependencies]
-tokio = { version = "1.52.3", features = ["full"] }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
-anyhow = "1.0.102"
-thiserror = "2.0.18"
-reqwest = { version = "0.13.3", default-features = false, features = ["json", "stream", "multipart", "rustls"] }
-clap = { version = "4.6.1", features = ["derive"] }
-uuid = { version = "1.23.1", features = ["v4"] }
-tokio-stream = "0.1.18"
+tokio = { version = "1.53.1", features = ["full"] }
+serde = { version = "1.0.229", features = ["derive"] }
+serde_json = "1.0.151"
+anyhow = "1.0.104"
+thiserror = "2.0.19"
+async-trait = "0.1.89"
+reqwest = { version = "0.13.4", default-features = false, features = ["json", "stream", "multipart", "rustls"] }
+clap = { version = "4.6.5", features = ["derive"] }
+uuid = { version = "1.24.0", features = ["v4"] }
+tokio-stream = "0.1.19"
 eventsource-stream = "0.2.3"
-futures = "0.3.32"
-chrono = { version = "0.4.44", features = ["serde"] }
+futures = "0.3.33"
+chrono = { version = "0.4.45", features = ["serde"] }
 indexmap = { version = "2.14.0", features = ["serde"] }
-jsonschema = "0.47.0"
+jsonschema = "0.49.2"
 async-stream = "0.3.6"
-bytes = "1.11.1"
-base64 = "0.22.1"
+bytes = "1.12.1"
+rtc = "0.20.0"
+base64 = "0.23.0"
 const_format = "0.2.36"
 paste = { package = "qlora-paste", version = "1.0.20" }
 # WebRTC dependencies for real-time audio
-webrtc = "0.17.1"
+webrtc = "0.20.0"
 # WebRTC signaling and peer connection
 tokio-tungstenite = "0.30.0"
 url = "2.5.8"
-rand = "0.10.1"
-log = "0.4.29"
+rand = "0.10.2"
+log = "0.4.33"
 
 # Optional YARA validation support
-yara-x = { version = "1.16.0", optional = true }
+yara-x = { version = "1.19.0", optional = true }
 
 [dev-dependencies]
 tokio-test = "0.4.5"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 
 # Base images are pinned by digest for reproducibility (Scorecard Pinned-Dependencies).
 # Refresh with: docker buildx imagetools inspect <image> | awk '/^Digest:/{print $2}'
-FROM rust:1.97.0-bookworm@sha256:7d0723df719e7f213b69dc7c8c595985c3f4b060cfbee4f7bc0e347a86fe3b6a AS rust-base
+FROM rust:1.97.1-bookworm@sha256:77fac8b98f9f46062bb680b6d25d5bcaabfc400143952ebc572e924bcbedc3fa AS rust-base
 
 ARG VERSION=0.0.0
 ARG BUILD_DATE=unknown
@@ -86,7 +86,7 @@ LABEL org.opencontainers.image.title="${OCI_IMAGE_TITLE}" \
       org.opencontainers.image.documentation="https://github.com/threatflux/openai_rust_sdk/blob/main/README.md" \
       com.threatflux.category="AI/ML SDK" \
       com.threatflux.capabilities="openai,batch-processing,yara-validation" \
-      com.threatflux.rust.version="1.96.0" \
+      com.threatflux.rust.version="1.97.1" \
       com.threatflux.rust.edition="2024"
 
 # tini is copied from the build stage for proper PID 1 signal handling/zombie

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 # Standardized build, test, and development commands for openai_rust_sdk.
 
 CARGO ?= cargo
-RUST_MSRV ?= 1.96.0
-RUST_TOOLCHAIN ?= 1.96.0
+RUST_MSRV ?= 1.97.1
+RUST_TOOLCHAIN ?= 1.97.1
 
 DOCKER_IMAGE ?= openai-rust-sdk
 DOCKER_TAG ?= latest

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-openai_rust_sdk = "0.1.0"
+openai_rust_sdk = "1.6.0"
 ```
 
 ## Quick Start
@@ -146,6 +146,13 @@ while let Some(event) = stream.next().await {
 # Ok::<(), Box<dyn std::error::Error>>(())
 # })?;
 ```
+
+The current Responses surface also supports GPT-5 reasoning controls, prompt-cache
+retention, truncation, tool search, shell/apply-patch/custom tools, background execution,
+input-token counting, conversation compaction, and typed reasoning/tool-call stream events.
+Realtime client secrets/transcription sessions and the current Videos API (including image
+references, edit, extend, remix, and content download) are available from `RealtimeAudioApi`
+and `VideosApi`.
 
 Compatibility helpers such as `generate_text`, `create_chat_completion`, and
 `create_custom_response` automatically route through the Responses API to maintain

--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -100,27 +100,43 @@ pub fn get_api_key_or_default(default_key: &str) -> String {
 mod tests {
     use super::*;
     use std::env;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn test_get_api_key_or_default() {
+        let _lock = ENV_LOCK.lock().unwrap();
         // Remove the env var if it exists for this test
         let original = env::var("OPENAI_API_KEY").ok();
-        env::remove_var("OPENAI_API_KEY");
+        // These tests run in isolation and restore the process environment below.
+        // nosemgrep: rust.lang.security.unsafe-usage.unsafe-usage -- test-only serialized environment setup
+        unsafe { env::remove_var("OPENAI_API_KEY") };
 
         let result = get_api_key_or_default("test-key");
         assert_eq!(result, "test-key");
 
         // Restore original value if it existed
         if let Some(original_key) = original {
-            env::set_var("OPENAI_API_KEY", original_key);
+            // nosemgrep: rust.lang.security.unsafe-usage.unsafe-usage -- test-only serialized environment restoration
+            unsafe { env::set_var("OPENAI_API_KEY", original_key) };
         }
     }
 
     #[test]
     fn test_try_get_api_key_with_key() {
-        env::set_var("OPENAI_API_KEY", "test-key");
+        let _lock = ENV_LOCK.lock().unwrap();
+        let original = env::var("OPENAI_API_KEY").ok();
+        // nosemgrep: rust.lang.security.unsafe-usage.unsafe-usage -- test-only serialized environment setup
+        unsafe { env::set_var("OPENAI_API_KEY", "test-key") };
         let result = try_get_api_key();
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), "test-key");
+        match original {
+            // nosemgrep: rust.lang.security.unsafe-usage.unsafe-usage -- test-only serialized environment restoration
+            Some(original_key) => unsafe { env::set_var("OPENAI_API_KEY", original_key) },
+            // nosemgrep: rust.lang.security.unsafe-usage.unsafe-usage -- test-only serialized environment restoration
+            None => unsafe { env::remove_var("OPENAI_API_KEY") },
+        }
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.96.0"
+channel = "1.97.1"
 components = ["clippy", "rustfmt", "llvm-tools-preview"]

--- a/src/api/realtime_audio_impl/client.rs
+++ b/src/api/realtime_audio_impl/client.rs
@@ -5,6 +5,10 @@
 use super::{config::RealtimeAudioConfig, session::RealtimeSession};
 use crate::api::base::HttpClient;
 use crate::error::{OpenAIError, Result};
+use crate::models::realtime::{
+    RealtimeClientSecretRequest, RealtimeClientSecretResponse, RealtimeTranscriptionSessionRequest,
+    RealtimeTranscriptionSessionResponse,
+};
 use crate::models::realtime_audio::{RealtimeSessionRequest, RealtimeSessionResponse};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -56,7 +60,7 @@ impl RealtimeAudioApi {
         &self,
         request: &RealtimeSessionRequest,
     ) -> Result<Arc<RealtimeSession>> {
-        let url = format!("{}/realtime/sessions", self.http_client.base_url());
+        let url = format!("{}/v1/realtime/sessions", self.http_client.base_url());
         let headers = self.http_client.build_headers()?;
 
         let response = self
@@ -86,9 +90,8 @@ impl RealtimeAudioApi {
             .await
             .map_err(crate::parse_err!(to_string))?;
 
-        let session = self
-            .create_webrtc_session(session_response, request.config.clone())
-            .await?;
+        let session =
+            Box::pin(self.create_webrtc_session(session_response, request.config.clone())).await?;
 
         // Store the session
         let mut sessions = self.sessions.write().await;
@@ -120,6 +123,26 @@ impl RealtimeAudioApi {
         Ok(())
     }
 
+    /// Create an ephemeral client secret for a Realtime or transcription session.
+    pub async fn create_client_secret(
+        &self,
+        request: &RealtimeClientSecretRequest,
+    ) -> Result<RealtimeClientSecretResponse> {
+        self.http_client
+            .post("/v1/realtime/client_secrets", request)
+            .await
+    }
+
+    /// Create a server-side Realtime transcription session.
+    pub async fn create_transcription_session(
+        &self,
+        request: &RealtimeTranscriptionSessionRequest,
+    ) -> Result<RealtimeTranscriptionSessionResponse> {
+        self.http_client
+            .post("/v1/realtime/transcription_sessions", request)
+            .await
+    }
+
     /// Get the HTTP client for internal use
     #[allow(dead_code)]
     pub(crate) fn http_client(&self) -> &HttpClient {
@@ -130,5 +153,65 @@ impl RealtimeAudioApi {
     #[allow(dead_code)]
     pub(crate) fn sessions(&self) -> &Arc<RwLock<HashMap<String, Arc<RealtimeSession>>>> {
         &self.sessions
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use httpmock::prelude::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn creates_current_realtime_rest_sessions() {
+        let server = MockServer::start_async().await;
+        let secret_mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path("/v1/realtime/client_secrets");
+                then.status(200)
+                    .header("Content-Type", "application/json")
+                    .json_body(json!({
+                        "value": "ek_test",
+                        "expires_at": 1_800_000_000,
+                        "session": {"type": "realtime", "model": "gpt-realtime"}
+                    }));
+            })
+            .await;
+        let transcription_mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/v1/realtime/transcription_sessions");
+                then.status(200)
+                    .header("Content-Type", "application/json")
+                    .json_body(json!({
+                        "client_secret": {"value": "ek_transcription", "expires_at": 1_800_000_000},
+                        "expires_at": 1_800_000_000
+                    }));
+            })
+            .await;
+
+        let api = RealtimeAudioApi::new_with_base_url("test-key", &server.base_url()).expect("API");
+        let secret_request = RealtimeClientSecretRequest::new(json!({
+            "type": "realtime",
+            "model": "gpt-realtime"
+        }))
+        .with_expiration_seconds(600);
+        let secret = api
+            .create_client_secret(&secret_request)
+            .await
+            .expect("client secret");
+        assert_eq!(secret.value, "ek_test");
+
+        let transcription = api
+            .create_transcription_session(&RealtimeTranscriptionSessionRequest::default())
+            .await
+            .expect("transcription session");
+        assert_eq!(
+            transcription.client_secret.expect("client secret").value,
+            "ek_transcription"
+        );
+
+        secret_mock.assert_async().await;
+        transcription_mock.assert_async().await;
     }
 }

--- a/src/api/realtime_audio_impl/config.rs
+++ b/src/api/realtime_audio_impl/config.rs
@@ -4,7 +4,7 @@
 
 use crate::models::realtime_audio::VoiceActivityDetectionConfig;
 use std::time::Duration;
-use webrtc::ice_transport::ice_server::RTCIceServer;
+use webrtc::peer_connection::RTCIceServer;
 
 /// Configuration for real-time audio API
 #[derive(Debug, Clone)]

--- a/src/api/realtime_audio_impl/session/handlers.rs
+++ b/src/api/realtime_audio_impl/session/handlers.rs
@@ -5,12 +5,12 @@
 use crate::error::{OpenAIError, Result};
 use crate::models::realtime_audio::{AudioBuffer, RealtimeEvent};
 use log::warn;
+use rtc::media::Sample;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
-use webrtc::data_channel::data_channel_message::DataChannelMessage;
-use webrtc::media::Sample;
-use webrtc::track::track_remote::TrackRemote;
+use webrtc::data_channel::RTCDataChannelMessage;
+use webrtc::media_stream::track_remote::{TrackRemote, TrackRemoteEvent};
 
 use super::types::RealtimeSession;
 
@@ -21,7 +21,7 @@ impl RealtimeSession {
             let json = serde_json::to_string(&event).map_err(crate::parse_err!(to_string))?;
 
             data_channel
-                .send_text(json)
+                .send_text(&json)
                 .await
                 .map_err(crate::streaming_err!("Failed to send event: {}"))?;
         } else {
@@ -48,6 +48,7 @@ impl RealtimeSession {
             };
 
             audio_track
+                .sample_writer(123_456, 111)
                 .write_sample(&sample)
                 .await
                 .map_err(crate::streaming_err!("Failed to send audio: {}"))?;
@@ -76,7 +77,7 @@ impl RealtimeSession {
     }
 
     /// Handle incoming data channel message
-    pub async fn handle_data_channel_message(&self, msg: DataChannelMessage) -> Result<()> {
+    pub async fn handle_data_channel_message(&self, msg: RTCDataChannelMessage) -> Result<()> {
         if let Ok(text) = String::from_utf8(msg.data.to_vec()) {
             match serde_json::from_str::<RealtimeEvent>(&text) {
                 Ok(event) => {
@@ -94,14 +95,14 @@ impl RealtimeSession {
     }
 
     /// Handle incoming audio track
-    pub async fn handle_incoming_track(&self, track: Arc<TrackRemote>) {
+    pub async fn handle_incoming_track(&self, track: Arc<dyn TrackRemote>) {
         let audio_sender = self.audio_sender().clone();
         let sample_rate = 24000; // Default sample rate for real-time audio
 
         tokio::spawn(async move {
             loop {
-                match track.read_rtp().await {
-                    Ok((rtp_packet, _)) => {
+                match track.poll().await {
+                    Some(TrackRemoteEvent::OnRtpPacket(rtp_packet)) => {
                         // Convert RTP packet to audio buffer
                         // This is a simplified conversion - in reality you'd need
                         // to handle Opus decoding properly
@@ -124,10 +125,11 @@ impl RealtimeSession {
                             break;
                         }
                     }
-                    Err(e) => {
-                        log::error!("Failed to read RTP packet: {e}");
+                    Some(TrackRemoteEvent::OnError | TrackRemoteEvent::OnEnded) | None => {
+                        log::error!("Incoming realtime audio track ended");
                         break;
                     }
+                    Some(_) => {}
                 }
             }
         });

--- a/src/api/realtime_audio_impl/session/types.rs
+++ b/src/api/realtime_audio_impl/session/types.rs
@@ -10,9 +10,9 @@ use chrono::{DateTime, Utc};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::{Mutex, mpsc};
-use webrtc::data_channel::RTCDataChannel;
-use webrtc::peer_connection::RTCPeerConnection;
-use webrtc::track::track_local::track_local_static_sample::TrackLocalStaticSample;
+use webrtc::data_channel::DataChannel;
+use webrtc::media_stream::track_local::static_sample::TrackLocalStaticSample;
+use webrtc::peer_connection::PeerConnection;
 
 use super::super::vad::VoiceActivityDetector;
 
@@ -22,10 +22,10 @@ pub struct RealtimeSession {
     pub id: String,
 
     /// WebRTC peer connection
-    peer_connection: Arc<RTCPeerConnection>,
+    peer_connection: Arc<dyn PeerConnection>,
 
     /// Data channel for events
-    data_channel: Arc<Mutex<Option<Arc<RTCDataChannel>>>>,
+    data_channel: Arc<Mutex<Option<Arc<dyn DataChannel>>>>,
 
     /// Audio track for sending
     audio_track: Arc<Mutex<Option<Arc<TrackLocalStaticSample>>>>,
@@ -69,7 +69,7 @@ impl RealtimeSession {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: String,
-        peer_connection: Arc<RTCPeerConnection>,
+        peer_connection: Arc<dyn PeerConnection>,
         event_sender: mpsc::UnboundedSender<RealtimeEvent>,
         event_receiver: mpsc::UnboundedReceiver<RealtimeEvent>,
         audio_sender: mpsc::UnboundedSender<AudioBuffer>,
@@ -144,7 +144,7 @@ impl RealtimeSession {
     }
 
     /// Set the data channel
-    pub async fn set_data_channel(&self, data_channel: Arc<RTCDataChannel>) {
+    pub async fn set_data_channel(&self, data_channel: Arc<dyn DataChannel>) {
         *self.data_channel.lock().await = Some(data_channel);
     }
 
@@ -164,7 +164,7 @@ impl RealtimeSession {
     }
 
     /// Get the peer connection
-    pub fn peer_connection(&self) -> &Arc<RTCPeerConnection> {
+    pub fn peer_connection(&self) -> &Arc<dyn PeerConnection> {
         &self.peer_connection
     }
 
@@ -174,7 +174,7 @@ impl RealtimeSession {
     }
 
     /// Get the data channel (for internal use)
-    pub(crate) async fn data_channel(&self) -> Option<Arc<RTCDataChannel>> {
+    pub(crate) async fn data_channel(&self) -> Option<Arc<dyn DataChannel>> {
         self.data_channel.lock().await.clone()
     }
 

--- a/src/api/realtime_audio_impl/webrtc/connection.rs
+++ b/src/api/realtime_audio_impl/webrtc/connection.rs
@@ -7,20 +7,20 @@ use crate::models::realtime_audio::{
     RealtimeEvent, RealtimeSessionConfig, RealtimeSessionResponse, WebRtcConnectionState,
 };
 use log::info;
+use rtc::peer_connection::configuration::media_engine::MIME_TYPE_OPUS;
+use rtc::rtp_transceiver::rtp_sender::{
+    RTCRtpCodec, RTCRtpCodingParameters, RTCRtpEncodingParameters, RtpCodecKind,
+};
 use std::sync::Arc;
+use tokio::sync::Mutex;
 use tokio::sync::mpsc;
-use webrtc::api::APIBuilder;
-use webrtc::api::interceptor_registry::register_default_interceptors;
-use webrtc::api::media_engine::{MIME_TYPE_OPUS, MediaEngine};
-use webrtc::data_channel::RTCDataChannel;
-use webrtc::data_channel::data_channel_init::RTCDataChannelInit;
-use webrtc::interceptor::registry::Registry;
-use webrtc::peer_connection::RTCPeerConnection;
-use webrtc::peer_connection::configuration::RTCConfiguration;
-use webrtc::peer_connection::peer_connection_state::RTCPeerConnectionState;
-use webrtc::rtp_transceiver::rtp_codec::RTCRtpCodecCapability;
-use webrtc::track::track_local::TrackLocal;
-use webrtc::track::track_local::track_local_static_sample::TrackLocalStaticSample;
+use webrtc::media_stream::MediaStreamTrack;
+use webrtc::media_stream::track_local::static_sample::TrackLocalStaticSample;
+use webrtc::media_stream::track_remote::TrackRemote;
+use webrtc::peer_connection::{
+    MediaEngine, PeerConnection, PeerConnectionBuilder, PeerConnectionEventHandler,
+    RTCConfigurationBuilder, RTCPeerConnectionState, Registry, register_default_interceptors,
+};
 
 use super::super::{
     client::RealtimeAudioApi, session::RealtimeSession, vad::VoiceActivityDetector,
@@ -46,8 +46,7 @@ impl RealtimeAudioApi {
         response: RealtimeSessionResponse,
         config: Option<RealtimeSessionConfig>,
     ) -> Result<Arc<RealtimeSession>> {
-        let api = self.create_webrtc_api().await?;
-        let peer_connection = self.create_peer_connection(api).await?;
+        let (peer_connection, handler) = Box::pin(self.create_peer_connection()).await?;
         let (event_channels, audio_channels) = self.create_communication_channels();
 
         let session = self.build_session(
@@ -57,44 +56,45 @@ impl RealtimeAudioApi {
             audio_channels,
             config,
         );
+        handler.set_session(Arc::downgrade(&session)).await;
 
         self.setup_webrtc_connection(&session, &response).await?;
         Ok(session)
     }
 
-    /// Creates and configures the WebRTC API
-    pub(crate) async fn create_webrtc_api(&self) -> Result<webrtc::api::API> {
+    /// Creates and configures a WebRTC peer connection.
+    pub(crate) async fn create_peer_connection(
+        &self,
+    ) -> Result<(Arc<dyn PeerConnection>, Arc<RealtimePeerConnectionHandler>)> {
         let mut media_engine = MediaEngine::default();
         media_engine
             .register_default_codecs()
             .map_err(crate::invalid_request_err!("Failed to register codecs: {}"))?;
 
-        let mut registry = Registry::new();
-        registry = register_default_interceptors(registry, &mut media_engine).map_err(|e| {
-            OpenAIError::InvalidRequest(format!("Failed to register interceptors: {e}"))
-        })?;
+        let registry =
+            register_default_interceptors(Registry::new(), &mut media_engine).map_err(|e| {
+                OpenAIError::InvalidRequest(format!("Failed to register interceptors: {e}"))
+            })?;
 
-        Ok(APIBuilder::new()
-            .with_media_engine(media_engine)
-            .with_interceptor_registry(registry)
-            .build())
-    }
-
-    /// Creates a WebRTC peer connection
-    pub(crate) async fn create_peer_connection(
-        &self,
-        api: webrtc::api::API,
-    ) -> Result<Arc<RTCPeerConnection>> {
-        let rtc_config = RTCConfiguration {
-            ice_servers: self.config.ice_servers.clone(),
-            ..Default::default()
-        };
-
-        let peer_connection = api.new_peer_connection(rtc_config).await.map_err(|e| {
+        let handler = Arc::new(RealtimePeerConnectionHandler::new());
+        let rtc_config = RTCConfigurationBuilder::default()
+            .with_ice_servers(self.config.ice_servers.clone())
+            .build();
+        let peer_connection = Box::pin(
+            PeerConnectionBuilder::new()
+                .with_configuration(rtc_config)
+                .with_media_engine(media_engine)
+                .with_interceptor_registry(registry)
+                .with_handler(handler.clone())
+                .with_udp_addrs(vec!["0.0.0.0:0"])
+                .build(),
+        )
+        .await
+        .map_err(|e| {
             OpenAIError::InvalidRequest(format!("Failed to create peer connection: {e}"))
         })?;
 
-        Ok(Arc::new(peer_connection))
+        Ok((Arc::new(peer_connection), handler))
     }
 
     /// Creates communication channels for events and audio
@@ -108,7 +108,7 @@ impl RealtimeAudioApi {
     pub(crate) fn build_session(
         &self,
         response: RealtimeSessionResponse,
-        peer_connection: &Arc<RTCPeerConnection>,
+        peer_connection: &Arc<dyn PeerConnection>,
         event_channels: EventChannels,
         audio_channels: AudioChannels,
         config: Option<RealtimeSessionConfig>,
@@ -171,15 +171,81 @@ impl RealtimeAudioApi {
     }
 
     /// Creates an audio track for Opus codec
-    pub(crate) fn create_audio_track(&self) -> Arc<TrackLocalStaticSample> {
-        Arc::new(TrackLocalStaticSample::new(
-            RTCRtpCodecCapability {
-                mime_type: MIME_TYPE_OPUS.to_owned(),
-                ..Default::default()
-            },
+    pub(crate) fn create_audio_track(&self) -> Result<Arc<TrackLocalStaticSample>> {
+        let track = MediaStreamTrack::new(
+            "realtime-audio".to_owned(),
             "audio".to_owned(),
             "realtime-audio".to_owned(),
-        ))
+            RtpCodecKind::Audio,
+            vec![RTCRtpEncodingParameters {
+                rtp_coding_parameters: RTCRtpCodingParameters {
+                    ssrc: Some(123_456),
+                    ..Default::default()
+                },
+                codec: RTCRtpCodec {
+                    mime_type: MIME_TYPE_OPUS.to_owned(),
+                    clock_rate: 48_000,
+                    channels: 2,
+                    ..Default::default()
+                },
+                ..Default::default()
+            }],
+        );
+
+        TrackLocalStaticSample::new(track)
+            .map(Arc::new)
+            .map_err(crate::invalid_request_err!(
+                "Failed to create audio track: {}"
+            ))
+    }
+}
+
+/// Bridges WebRTC callbacks to the owning realtime session.
+pub(crate) struct RealtimePeerConnectionHandler {
+    /// Weak reference to the session receiving WebRTC callbacks.
+    session: Arc<Mutex<Option<std::sync::Weak<RealtimeSession>>>>,
+}
+
+impl RealtimePeerConnectionHandler {
+    /// Create a handler before the session is built.
+    fn new() -> Self {
+        Self {
+            session: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// Attach the session after the peer connection has been constructed.
+    async fn set_session(&self, session: std::sync::Weak<RealtimeSession>) {
+        *self.session.lock().await = Some(session);
+    }
+}
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for RealtimePeerConnectionHandler {
+    async fn on_connection_state_change(&self, state: RTCPeerConnectionState) {
+        if let Some(session) = self
+            .session
+            .lock()
+            .await
+            .as_ref()
+            .and_then(|weak| weak.upgrade())
+        {
+            session
+                .set_connection_state(map_webrtc_connection_state(state))
+                .await;
+        }
+    }
+
+    async fn on_track(&self, track: Arc<dyn TrackRemote>) {
+        if let Some(session) = self
+            .session
+            .lock()
+            .await
+            .as_ref()
+            .and_then(|weak| weak.upgrade())
+        {
+            session.handle_incoming_track(track).await;
+        }
     }
 }
 
@@ -193,5 +259,101 @@ pub(crate) fn map_webrtc_connection_state(state: RTCPeerConnectionState) -> WebR
         RTCPeerConnectionState::Failed => WebRtcConnectionState::Failed,
         RTCPeerConnectionState::Closed => WebRtcConnectionState::Closed,
         _ => WebRtcConnectionState::New,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::realtime_audio::{RealtimeSessionConfig, SessionStatus};
+    use chrono::Utc;
+
+    fn test_session_response() -> RealtimeSessionResponse {
+        let now = Utc::now();
+        RealtimeSessionResponse {
+            id: "realtime-test".to_owned(),
+            object: "realtime.session".to_owned(),
+            status: SessionStatus::Active,
+            ephemeral_key: "ephemeral-test".to_owned(),
+            webrtc_url: "https://example.test/realtime".to_owned(),
+            config: RealtimeSessionConfig::default(),
+            expires_at: now,
+            created_at: now,
+        }
+    }
+
+    #[test]
+    fn maps_all_peer_connection_states() {
+        assert_eq!(
+            map_webrtc_connection_state(RTCPeerConnectionState::New),
+            WebRtcConnectionState::New
+        );
+        assert_eq!(
+            map_webrtc_connection_state(RTCPeerConnectionState::Connecting),
+            WebRtcConnectionState::Connecting
+        );
+        assert_eq!(
+            map_webrtc_connection_state(RTCPeerConnectionState::Connected),
+            WebRtcConnectionState::Connected
+        );
+        assert_eq!(
+            map_webrtc_connection_state(RTCPeerConnectionState::Disconnected),
+            WebRtcConnectionState::Disconnected
+        );
+        assert_eq!(
+            map_webrtc_connection_state(RTCPeerConnectionState::Failed),
+            WebRtcConnectionState::Failed
+        );
+        assert_eq!(
+            map_webrtc_connection_state(RTCPeerConnectionState::Closed),
+            WebRtcConnectionState::Closed
+        );
+    }
+
+    #[tokio::test]
+    async fn creates_and_connects_local_webrtc_session() {
+        let api = RealtimeAudioApi::new("test-key").expect("API");
+        let session = api
+            .create_webrtc_session(test_session_response(), None)
+            .await
+            .expect("local WebRTC session");
+
+        assert!(session.data_channel().await.is_some());
+        assert!(session.audio_track().await.is_some());
+        assert_eq!(session.connection_state().await, WebRtcConnectionState::New);
+
+        api.connect_webrtc(&session).await.expect("local offer");
+        assert_eq!(
+            session.connection_state().await,
+            WebRtcConnectionState::Connected
+        );
+
+        session.close().await.expect("close session");
+        assert!(!session.is_active());
+    }
+
+    #[tokio::test]
+    async fn handler_updates_attached_session_state() {
+        let api = RealtimeAudioApi::new("test-key").expect("API");
+        let (peer_connection, handler) = api.create_peer_connection().await.expect("peer");
+        let (event_channels, audio_channels) = api.create_communication_channels();
+        let session = api.build_session(
+            test_session_response(),
+            &peer_connection,
+            event_channels,
+            audio_channels,
+            None,
+        );
+
+        handler.set_session(Arc::downgrade(&session)).await;
+        handler
+            .on_connection_state_change(RTCPeerConnectionState::Failed)
+            .await;
+        assert_eq!(
+            session.connection_state().await,
+            WebRtcConnectionState::Failed
+        );
+
+        session.close().await.expect("close session");
     }
 }

--- a/src/api/realtime_audio_impl/webrtc/setup.rs
+++ b/src/api/realtime_audio_impl/webrtc/setup.rs
@@ -4,15 +4,11 @@
 
 use crate::error::{OpenAIError, Result};
 use crate::models::realtime_audio::RealtimeSessionResponse;
-use log::info;
 use std::sync::Arc;
-use webrtc::data_channel::RTCDataChannel;
-use webrtc::data_channel::data_channel_init::RTCDataChannelInit;
-use webrtc::track::track_local::TrackLocal;
-use webrtc::track::track_local::track_local_static_sample::TrackLocalStaticSample;
+use webrtc::data_channel::{DataChannel, DataChannelEvent, RTCDataChannelInit};
+use webrtc::media_stream::track_local::{TrackLocal, static_sample::TrackLocalStaticSample};
 
 use super::super::{client::RealtimeAudioApi, session::RealtimeSession};
-use super::connection::map_webrtc_connection_state;
 
 impl RealtimeAudioApi {
     /// Set up WebRTC connection
@@ -23,27 +19,10 @@ impl RealtimeAudioApi {
     ) -> Result<()> {
         let session_weak = Arc::downgrade(session);
 
-        self.setup_connection_state_handler(session).await;
         self.setup_data_channel(session, &session_weak).await?;
-        self.setup_audio_track(session, &session_weak).await?;
+        self.setup_audio_track(session).await?;
 
         Ok(())
-    }
-
-    /// Sets up the connection state change handler
-    async fn setup_connection_state_handler(&self, session: &Arc<RealtimeSession>) {
-        let session_clone = session.clone();
-        let peer_connection = session.peer_connection();
-
-        peer_connection.on_peer_connection_state_change(Box::new(move |state| {
-            let session_clone = session_clone.clone();
-            Box::pin(async move {
-                let webrtc_state = map_webrtc_connection_state(state);
-                session_clone.set_connection_state(webrtc_state).await;
-
-                info!("WebRTC connection state changed to: {:?}", webrtc_state);
-            })
-        }));
     }
 
     /// Sets up the data channel for event communication
@@ -58,7 +37,7 @@ impl RealtimeAudioApi {
             .create_data_channel(
                 "events",
                 Some(RTCDataChannelInit {
-                    ordered: Some(true),
+                    ordered: true,
                     ..Default::default()
                 }),
             )
@@ -68,7 +47,7 @@ impl RealtimeAudioApi {
             })?;
 
         session.set_data_channel(data_channel.clone()).await;
-        self.setup_data_channel_handlers(&data_channel, session_weak);
+        self.setup_data_channel_handlers(data_channel, session_weak);
 
         Ok(())
     }
@@ -76,34 +55,34 @@ impl RealtimeAudioApi {
     /// Sets up data channel message handlers
     fn setup_data_channel_handlers(
         &self,
-        data_channel: &Arc<RTCDataChannel>,
+        data_channel: Arc<dyn DataChannel>,
         session_weak: &std::sync::Weak<RealtimeSession>,
     ) {
         let session_for_events = session_weak.clone();
-        data_channel.on_message(Box::new(move |msg| {
-            let session_for_events = session_for_events.clone();
-            Box::pin(async move {
-                if let Some(session) = session_for_events.upgrade()
-                    && let Err(e) = session.handle_data_channel_message(msg).await
-                {
-                    log::error!("Failed to handle data channel message: {e}");
+        tokio::spawn(async move {
+            while let Some(event) = data_channel.poll().await {
+                match event {
+                    DataChannelEvent::OnMessage(msg) => {
+                        if let Some(session) = session_for_events.upgrade()
+                            && let Err(e) = session.handle_data_channel_message(msg).await
+                        {
+                            log::error!("Failed to handle data channel message: {e}");
+                        }
+                    }
+                    DataChannelEvent::OnClose => break,
+                    _ => {}
                 }
-            })
-        }));
+            }
+        });
     }
 
     /// Sets up audio track for sending audio
-    async fn setup_audio_track(
-        &self,
-        session: &Arc<RealtimeSession>,
-        session_weak: &std::sync::Weak<RealtimeSession>,
-    ) -> Result<()> {
-        let audio_track = self.create_audio_track();
+    async fn setup_audio_track(&self, session: &Arc<RealtimeSession>) -> Result<()> {
+        let audio_track = self.create_audio_track()?;
         session.set_audio_track(audio_track.clone()).await;
 
         self.add_audio_track_to_connection(session, audio_track)
             .await?;
-        self.setup_incoming_track_handler(session, session_weak);
 
         Ok(())
     }
@@ -116,28 +95,9 @@ impl RealtimeAudioApi {
     ) -> Result<()> {
         let peer_connection = session.peer_connection();
         let _rtp_sender = peer_connection
-            .add_track(audio_track as Arc<dyn TrackLocal + Send + Sync>)
+            .add_track(audio_track as Arc<dyn TrackLocal>)
             .await
             .map_err(crate::invalid_request_err!("Failed to add audio track: {}"))?;
         Ok(())
-    }
-
-    /// Sets up handler for incoming audio tracks
-    fn setup_incoming_track_handler(
-        &self,
-        session: &Arc<RealtimeSession>,
-        session_weak: &std::sync::Weak<RealtimeSession>,
-    ) {
-        let peer_connection = session.peer_connection();
-        let session_for_track = session_weak.clone();
-
-        peer_connection.on_track(Box::new(move |track, _receiver, _transceiver| {
-            let session_for_track = session_for_track.clone();
-            Box::pin(async move {
-                if let Some(session) = session_for_track.upgrade() {
-                    session.handle_incoming_track(track).await;
-                }
-            })
-        }));
     }
 }

--- a/src/api/responses_v2.rs
+++ b/src/api/responses_v2.rs
@@ -5,8 +5,8 @@ use crate::api::common::{
 use crate::api::shared_utilities::EnumConverter;
 use crate::error::{ApiErrorResponse, OpenAIError, Result};
 use crate::models::responses_v2::{
-    ContentPart, CreateResponseRequest, ResponseInput, ResponseItem, ResponseObject,
-    ResponseStreamEvent,
+    ContentPart, CreateResponseRequest, InputTokenCountResponse, ResponseInput, ResponseItem,
+    ResponseObject, ResponseStreamEvent,
 };
 use crate::{De, Ser};
 use eventsource_stream::Eventsource;
@@ -143,28 +143,43 @@ impl ResponsesApiV2 {
             .map_err(OpenAIError::from)
     }
 
-    /// Compact a response (server-side context compaction)
+    /// Compact a conversation with the current Responses compaction endpoint.
     ///
-    /// Reduces the size of a stored response's context while preserving key information.
+    /// The request is sent to `POST /v1/responses/compact`; compaction is based on
+    /// the supplied model and input (or a previous response identifier).
     pub async fn compact_response(
         &self,
-        response_id: impl AsRef<str>,
-        background: Option<bool>,
+        request: &CreateResponseRequest,
     ) -> Result<ResponseObject> {
-        let url = format!("/v1/responses/{}/compact", response_id.as_ref());
-        let mut body = serde_json::json!({});
-        if let Some(bg) = background {
-            body["background"] = serde_json::json!(bg);
+        let mut body = request.to_payload()?;
+        if let Value::Object(payload) = &mut body {
+            payload.retain(|key, _| {
+                matches!(
+                    key.as_str(),
+                    "model"
+                        | "input"
+                        | "previous_response_id"
+                        | "instructions"
+                        | "prompt_cache_key"
+                        | "prompt_cache_options"
+                        | "service_tier"
+                )
+            });
         }
-        self.http_client.post(&url, &body).await
+        self.http_client.post("/v1/responses/compact", &body).await
     }
 
-    /// Count input tokens for a response
+    /// Count input tokens for a Responses request.
     ///
-    /// Returns the number of tokens that would be consumed by the given input.
-    pub async fn count_input_tokens(&self, response_id: impl AsRef<str>) -> Result<Value> {
-        let url = format!("/v1/responses/{}/input_tokens/count", response_id.as_ref());
-        self.http_client.post(&url, &Value::Null).await
+    /// Returns the number of tokens consumed by the request's input.
+    pub async fn count_input_tokens(
+        &self,
+        request: &CreateResponseRequest,
+    ) -> Result<InputTokenCountResponse> {
+        let body = request.to_payload()?;
+        self.http_client
+            .post("/v1/responses/input_tokens", &body)
+            .await
     }
 
     /// List input items used to generate a response
@@ -323,6 +338,32 @@ mod tests {
     }
 
     #[test]
+    fn parse_current_reasoning_event_returns_typed_variant() {
+        let event = Event {
+            id: String::new(),
+            event: "response.reasoning_summary_text.delta".into(),
+            data: json!({
+                "type": "response.reasoning_summary_text.delta",
+                "item_id": "rs_1",
+                "output_index": 0,
+                "summary_index": 0,
+                "delta": "Planning",
+                "sequence_number": 1
+            })
+            .to_string(),
+            retry: None,
+        };
+
+        let parsed = parse_sse_event(Ok(event)).expect("some").expect("ok");
+        match parsed {
+            ResponseStreamEvent::ReasoningSummaryTextDelta { delta, .. } => {
+                assert_eq!(delta, "Planning");
+            }
+            other => panic!("unexpected event: {:?}", other),
+        }
+    }
+
+    #[test]
     fn parse_error_event_maps_to_stream_error() {
         let event = Event {
             id: String::new(),
@@ -418,6 +459,12 @@ mod tests {
             "has_more": false
         })
         .to_string();
+        let compact_body = sample_response("Compacted").to_string();
+        let input_tokens_body = json!({
+            "object": "response.input_tokens",
+            "input_tokens": 17
+        })
+        .to_string();
 
         let completed_event = json!({
             "type": "response.completed",
@@ -508,6 +555,24 @@ event: response.completed\ndata: {}\n\n",
             })
             .await;
 
+        let compact_mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path("/v1/responses/compact");
+                then.status(200)
+                    .header("Content-Type", "application/json")
+                    .body(&compact_body);
+            })
+            .await;
+
+        let input_tokens_mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path("/v1/responses/input_tokens");
+                then.status(200)
+                    .header("Content-Type", "application/json")
+                    .body(&input_tokens_body);
+            })
+            .await;
+
         let api = ResponsesApiV2::new_with_base_url("test-key", &server.base_url()).unwrap();
         let request = CreateResponseRequest::new_text("gpt-4o-mini", "Hello");
 
@@ -560,6 +625,12 @@ event: response.completed\ndata: {}\n\n",
             .unwrap();
         assert_eq!(items.data.len(), 1);
 
+        let compacted = api.compact_response(&request).await.unwrap();
+        assert_eq!(compacted.output_text(), "Compacted");
+
+        let input_tokens = api.count_input_tokens(&request).await.unwrap();
+        assert_eq!(input_tokens.input_tokens, 17);
+
         stream_mock.assert_async().await;
         create_mock.assert_async().await;
         retrieve_mock.assert_async().await;
@@ -567,5 +638,7 @@ event: response.completed\ndata: {}\n\n",
         delete_mock.assert_async().await;
         list_mock.assert_async().await;
         input_items_mock.assert_async().await;
+        compact_mock.assert_async().await;
+        input_tokens_mock.assert_async().await;
     }
 }

--- a/src/api/videos.rs
+++ b/src/api/videos.rs
@@ -7,8 +7,10 @@ use crate::api::base::HttpClient;
 use crate::api::common::ApiClientConstructors;
 use crate::error::Result;
 use crate::models::videos::{
-    CreateVideoRequest, ListVideosParams, Video, VideoDeleteResponse, VideoList,
+    CreateVideoRequest, EditVideoRequest, ExtendVideoRequest, ListVideosParams, RemixVideoRequest,
+    Video, VideoDeleteResponse, VideoList,
 };
+use serde_json::Value;
 
 /// Videos API client for Sora video generation
 pub struct VideosApi {
@@ -27,7 +29,8 @@ impl ApiClientConstructors for VideosApi {
 impl VideosApi {
     /// Generate a new video from a text prompt
     pub async fn create_video(&self, request: &CreateVideoRequest) -> Result<Video> {
-        self.client.post("/v1/videos/generations", request).await
+        let payload = current_video_payload(request)?;
+        self.client.post("/v1/videos", &payload).await
     }
 
     /// Retrieve a video by ID
@@ -64,6 +67,71 @@ impl VideosApi {
         let path = format!("/v1/videos/{}", video_id.as_ref());
         self.client.delete(&path).await
     }
+
+    /// Edit a completed generated video.
+    pub async fn edit_video(&self, request: &EditVideoRequest) -> Result<Video> {
+        self.client.post("/v1/videos/edits", request).await
+    }
+
+    /// Extend a completed generated video.
+    pub async fn extend_video(&self, request: &ExtendVideoRequest) -> Result<Video> {
+        self.client.post("/v1/videos/extensions", request).await
+    }
+
+    /// Remix a completed generated video with a refreshed prompt.
+    pub async fn remix_video(
+        &self,
+        video_id: impl AsRef<str>,
+        request: &RemixVideoRequest,
+    ) -> Result<Video> {
+        let path = format!("/v1/videos/{}/remix", video_id.as_ref());
+        self.client.post(&path, request).await
+    }
+
+    /// Download the rendered video or a derived preview asset.
+    pub async fn download_video_content(
+        &self,
+        video_id: impl AsRef<str>,
+        variant: Option<&str>,
+    ) -> Result<Vec<u8>> {
+        let path = match variant {
+            Some(variant) => format!("/v1/videos/{}/content?variant={variant}", video_id.as_ref()),
+            None => format!("/v1/videos/{}/content", video_id.as_ref()),
+        };
+        self.client.get_bytes(&path).await
+    }
+}
+
+/// Convert the compatibility request shape to the current Videos API payload.
+fn current_video_payload(request: &CreateVideoRequest) -> Result<Value> {
+    let mut payload = serde_json::to_value(request).map_err(crate::parse_err!(to_string))?;
+    if let Value::Object(fields) = &mut payload {
+        if !fields.contains_key("seconds")
+            && let Some(duration) = request.duration
+        {
+            let seconds = if duration.fract() == 0.0 {
+                format!("{duration:.0}")
+            } else {
+                duration.to_string()
+            };
+            fields.insert("seconds".to_string(), Value::String(seconds));
+        }
+
+        if !fields.contains_key("size")
+            && let (Some(width), Some(height)) = (request.width, request.height)
+        {
+            fields.insert(
+                "size".to_string(),
+                Value::String(format!("{width}x{height}")),
+            );
+        }
+
+        fields.remove("duration");
+        fields.remove("width");
+        fields.remove("height");
+        fields.remove("n");
+    }
+    Ok(payload)
 }
 
 #[cfg(test)]
@@ -112,6 +180,21 @@ mod tests {
         assert!(json.get("duration").is_none());
         assert!(json.get("width").is_none());
         assert!(json.get("n").is_none());
+    }
+
+    #[test]
+    fn current_video_payload_maps_legacy_fields_to_current_api() {
+        let request = CreateVideoRequest::new("sora-2", "A cat in space")
+            .with_duration(8.0)
+            .with_width(1280)
+            .with_height(720);
+        let payload = current_video_payload(&request).expect("payload");
+
+        assert_eq!(payload["seconds"], "8");
+        assert_eq!(payload["size"], "1280x720");
+        assert!(payload.get("duration").is_none());
+        assert!(payload.get("width").is_none());
+        assert!(payload.get("height").is_none());
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -647,8 +647,7 @@ mod tests {
     fn test_from_env_with_custom_base_url() {
         let _guard = ENV_LOCK.lock().expect("lock poisoned");
 
-        // SAFETY: test runs under ENV_LOCK so no concurrent env access.
-        // nosemgrep: rust.lang.security.unsafe-usage.unsafe-usage
+        // SAFETY: ENV_LOCK prevents concurrent environment access in this test module.
         unsafe {
             std::env::set_var("OPENAI_API_KEY", "test-key");
             std::env::set_var("OPENAI_BASE_URL", "https://example-proxy.test/v1");
@@ -660,8 +659,7 @@ mod tests {
             "https://example-proxy.test/v1"
         );
 
-        // SAFETY: test runs under ENV_LOCK so no concurrent env access.
-        // nosemgrep: rust.lang.security.unsafe-usage.unsafe-usage
+        // SAFETY: ENV_LOCK prevents concurrent environment access in this test module.
         unsafe {
             std::env::remove_var("OPENAI_API_KEY");
             std::env::remove_var("OPENAI_BASE_URL");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,6 +173,10 @@ pub use api::{
 pub use builders::{FunctionBuilder, ObjectSchemaBuilder};
 pub use client::{ChatBuilder, OpenAIClient, from_env, from_env_with_base_url};
 pub use error::{OpenAIError, Result};
+pub use models::realtime::*;
+pub use models::responses_v2::{
+    CreateResponseRequest, InputTokenCountResponse, ResponseStreamEvent,
+};
 pub use models::{assistants::*, functions::*, responses::*};
 pub use prompt_engineering::{
     Example, PromptBuilder, PromptPatterns, PromptTemplateBuilder, XmlContentBuilder,

--- a/src/models/gpt5.rs
+++ b/src/models/gpt5.rs
@@ -5,6 +5,21 @@ use serde::{self, Deserialize, Serialize};
 
 /// GPT-5 model constants
 pub mod models {
+    /// GPT-5.6 Sol - latest high-end reasoning model.
+    pub const GPT_5_6_SOL: &str = "gpt-5.6-sol";
+    /// GPT-5.6 Terra - latest balanced reasoning model.
+    pub const GPT_5_6_TERRA: &str = "gpt-5.6-terra";
+    /// GPT-5.6 Luna - latest efficient reasoning model.
+    pub const GPT_5_6_LUNA: &str = "gpt-5.6-luna";
+    /// GPT-5.4 - current general-purpose reasoning model.
+    pub const GPT_5_4: &str = "gpt-5.4";
+    /// GPT-5.4 Mini - current compact reasoning model.
+    pub const GPT_5_4_MINI: &str = "gpt-5.4-mini";
+    /// GPT-5.4 Nano - current high-throughput reasoning model.
+    pub const GPT_5_4_NANO: &str = "gpt-5.4-nano";
+    /// GPT-5.3 Chat Latest - current chat-optimized model.
+    pub const GPT_5_3_CHAT_LATEST: &str = "gpt-5.3-chat-latest";
+
     /// GPT-5 models - Latest reasoning models
     pub const GPT_5: &str = "gpt-5";
     /// GPT-5 Mini - Smaller, faster version of GPT-5
@@ -15,10 +30,19 @@ pub mod models {
     pub const GPT_5_CHAT_LATEST: &str = "gpt-5-chat-latest";
 
     /// Model snapshots with dates
+    pub const GPT_5_2025_08_07: &str = "gpt-5-2025-08-07";
+    /// GPT-5 snapshot from 2025-01-01 (deprecated; retained for compatibility).
+    #[deprecated(note = "use GPT_5_2025_08_07")]
     pub const GPT_5_2025_01_01: &str = "gpt-5-2025-01-01";
-    /// GPT-5 Mini snapshot from 2025-01-01
+    /// GPT-5 Mini snapshot from 2025-08-07.
+    pub const GPT_5_MINI_2025_08_07: &str = "gpt-5-mini-2025-08-07";
+    /// GPT-5 Mini snapshot from 2025-01-01 (deprecated; retained for compatibility).
+    #[deprecated(note = "use GPT_5_MINI_2025_08_07")]
     pub const GPT_5_MINI_2025_01_01: &str = "gpt-5-mini-2025-01-01";
-    /// GPT-5 Nano snapshot from 2025-01-01
+    /// GPT-5 Nano snapshot from 2025-08-07.
+    pub const GPT_5_NANO_2025_08_07: &str = "gpt-5-nano-2025-08-07";
+    /// GPT-5 Nano snapshot from 2025-01-01 (deprecated; retained for compatibility).
+    #[deprecated(note = "use GPT_5_NANO_2025_08_07")]
     pub const GPT_5_NANO_2025_01_01: &str = "gpt-5-nano-2025-01-01";
 
     /// GPT-4.1 models
@@ -46,6 +70,8 @@ pub mod models {
 #[derive(Debug, Clone, Copy, Ser, De, PartialEq, Eq, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum ReasoningEffort {
+    /// Disable reasoning where supported.
+    None,
     /// Very few reasoning tokens for fastest time-to-first-token
     Minimal,
     /// Favors speed and fewer tokens (default for o3-like behavior)
@@ -55,6 +81,73 @@ pub enum ReasoningEffort {
     Medium,
     /// More thorough reasoning for complex tasks
     High,
+    /// Extra-high reasoning effort.
+    XHigh,
+    /// Maximum reasoning effort for models that support it.
+    Max,
+}
+
+/// Reasoning execution mode.
+#[derive(Debug, Clone, Copy, Ser, De, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ReasoningMode {
+    /// Standard reasoning execution.
+    Standard,
+    /// Pro reasoning execution.
+    Pro,
+}
+
+/// Reasoning summary detail requested from the model.
+#[derive(Debug, Clone, Copy, Ser, De, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ReasoningSummary {
+    /// Let the model choose the summary detail.
+    Auto,
+    /// Return a concise summary.
+    Concise,
+    /// Return a detailed summary.
+    Detailed,
+}
+
+/// Which reasoning items should be carried into later turns.
+#[derive(Debug, Clone, Copy, Ser, De, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReasoningContext {
+    /// Let the model choose the context mode.
+    Auto,
+    /// Keep only the current turn's reasoning.
+    CurrentTurn,
+    /// Keep reasoning from all turns.
+    AllTurns,
+}
+
+/// Prompt-cache retention mode for GPT-5.6 and later.
+#[derive(Debug, Clone, Copy, Ser, De, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum PromptCacheMode {
+    /// Allow the service to create an implicit breakpoint.
+    Implicit,
+    /// Use only explicit breakpoints.
+    Explicit,
+}
+
+/// Prompt-cache time-to-live.
+#[derive(Debug, Clone, Copy, Ser, De, PartialEq, Eq)]
+pub enum PromptCacheTtl {
+    /// Retain cache entries for at least thirty minutes.
+    #[serde(rename = "30m")]
+    ThirtyMinutes,
+}
+
+/// Prompt-cache controls for GPT-5.6 and later.
+#[derive(Debug, Clone, Ser, De, Default)]
+pub struct PromptCacheOptions {
+    /// Minimum cache retention period.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ttl: Option<PromptCacheTtl>,
+    /// Implicit or explicit breakpoint behavior.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode: Option<PromptCacheMode>,
 }
 
 /// Verbosity levels for GPT-5 output
@@ -73,9 +166,18 @@ pub enum Verbosity {
 /// Reasoning configuration for GPT-5 models
 #[derive(Debug, Clone, Ser, De, Default)]
 pub struct ReasoningConfig {
+    /// Standard or pro reasoning execution.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode: Option<ReasoningMode>,
     /// The effort level for reasoning
     #[serde(skip_serializing_if = "Option::is_none")]
     pub effort: Option<ReasoningEffort>,
+    /// Summary detail to return.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<ReasoningSummary>,
+    /// Reasoning context retained across turns.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context: Option<ReasoningContext>,
 }
 
 impl ReasoningConfig {
@@ -83,7 +185,10 @@ impl ReasoningConfig {
     #[must_use]
     pub fn new(effort: ReasoningEffort) -> Self {
         Self {
+            mode: None,
             effort: Some(effort),
+            summary: None,
+            context: None,
         }
     }
 
@@ -109,6 +214,33 @@ impl ReasoningConfig {
     #[must_use]
     pub fn high() -> Self {
         Self::new(ReasoningEffort::High)
+    }
+
+    /// Create a maximum-effort reasoning config.
+    #[must_use]
+    pub fn max() -> Self {
+        Self::new(ReasoningEffort::Max)
+    }
+
+    /// Set the reasoning execution mode.
+    #[must_use]
+    pub fn with_mode(mut self, mode: ReasoningMode) -> Self {
+        self.mode = Some(mode);
+        self
+    }
+
+    /// Set the reasoning summary detail.
+    #[must_use]
+    pub fn with_summary(mut self, summary: ReasoningSummary) -> Self {
+        self.summary = Some(summary);
+        self
+    }
+
+    /// Set the cross-turn reasoning context.
+    #[must_use]
+    pub fn with_context(mut self, context: ReasoningContext) -> Self {
+        self.context = Some(context);
+        self
     }
 }
 
@@ -167,31 +299,31 @@ impl GPT5ModelSelector {
     /// Select the best model for complex reasoning tasks
     #[must_use]
     pub fn for_complex_reasoning() -> &'static str {
-        models::GPT_5
+        models::GPT_5_6_SOL
     }
 
     /// Select the best model for cost-optimized reasoning
     #[must_use]
     pub fn for_cost_optimized() -> &'static str {
-        models::GPT_5_MINI
+        models::GPT_5_4_MINI
     }
 
     /// Select the best model for high-throughput tasks
     #[must_use]
     pub fn for_high_throughput() -> &'static str {
-        models::GPT_5_NANO
+        models::GPT_5_4_NANO
     }
 
     /// Select the best model for coding tasks
     #[must_use]
     pub fn for_coding() -> &'static str {
-        models::GPT_5
+        models::GPT_5_4
     }
 
     /// Select the best model for chat applications
     #[must_use]
     pub fn for_chat() -> &'static str {
-        models::GPT_5_CHAT_LATEST
+        models::GPT_5_3_CHAT_LATEST
     }
 
     /// Get migration recommendation from an older model
@@ -204,5 +336,53 @@ impl GPT5ModelSelector {
             "gpt-4.1-nano" | "gpt-3.5-turbo" => models::GPT_5_NANO,
             _ => models::GPT_5,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn current_reasoning_configuration_serializes() {
+        let config = ReasoningConfig::max()
+            .with_mode(ReasoningMode::Pro)
+            .with_summary(ReasoningSummary::Detailed)
+            .with_context(ReasoningContext::AllTurns);
+        let value = serde_json::to_value(config).expect("reasoning JSON");
+
+        assert_eq!(value["effort"], "max");
+        assert_eq!(value["mode"], "pro");
+        assert_eq!(value["summary"], "detailed");
+        assert_eq!(value["context"], "all_turns");
+    }
+
+    #[test]
+    fn current_prompt_cache_configuration_serializes() {
+        let options = PromptCacheOptions {
+            ttl: Some(PromptCacheTtl::ThirtyMinutes),
+            mode: Some(PromptCacheMode::Explicit),
+        };
+        let value = serde_json::to_value(options).expect("prompt cache JSON");
+        assert_eq!(value, json!({"ttl": "30m", "mode": "explicit"}));
+    }
+
+    #[test]
+    fn current_model_selector_prefers_latest_models() {
+        assert_eq!(
+            GPT5ModelSelector::for_complex_reasoning(),
+            models::GPT_5_6_SOL
+        );
+        assert_eq!(
+            GPT5ModelSelector::for_cost_optimized(),
+            models::GPT_5_4_MINI
+        );
+        assert_eq!(
+            GPT5ModelSelector::for_high_throughput(),
+            models::GPT_5_4_NANO
+        );
+        assert_eq!(GPT5ModelSelector::for_coding(), models::GPT_5_4);
+        assert_eq!(GPT5ModelSelector::for_chat(), models::GPT_5_3_CHAT_LATEST);
     }
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -36,6 +36,8 @@ pub mod models;
 pub mod moderations;
 /// Modular moderations models for content policy classification
 pub mod moderations_modular;
+/// Current REST models for ephemeral Realtime sessions
+pub mod realtime;
 /// Real-time audio models for WebRTC streaming
 pub mod realtime_audio;
 /// Response models and data structures
@@ -127,6 +129,9 @@ pub use functions::{
 // GPT-5 API
 pub use gpt5::*;
 
+// Current REST Realtime session models
+pub use realtime::*;
+
 // Images API - explicit exports to avoid conflicts
 pub use images::builders as image_builders;
 pub use images::requests as image_requests;
@@ -164,11 +169,12 @@ pub use responses_v2::{
     CompletionTokenDetails as ResponsesApiCompletionTokenDetails,
     ContentPart as ResponsesApiContentPart, ConversationObject as ResponsesApiConversationObject,
     ConversationReference as ResponsesApiConversationReference, CreateResponseRequest,
+    InputTokenCountResponse as ResponsesApiInputTokenCountResponse,
     Instructions as ResponsesApiInstructions, PromptTokenDetails as ResponsesApiPromptTokenDetails,
     ResponseError as ResponsesApiError, ResponseInput as ResponsesApiInput,
     ResponseItem as ResponsesApiItem, ResponseObject, ResponseStatus, ResponseStreamEvent,
     ResponseUsage as ResponsesApiUsage, ServiceTier as ResponsesApiServiceTier,
-    StreamOptions as ResponsesApiStreamOptions,
+    StreamOptions as ResponsesApiStreamOptions, Truncation as ResponsesApiTruncation,
 };
 
 // Runs API

--- a/src/models/realtime.rs
+++ b/src/models/realtime.rs
@@ -1,0 +1,135 @@
+//! Current REST models for ephemeral Realtime and transcription sessions.
+
+use crate::{De, Ser};
+use serde_json::Value;
+use std::collections::HashMap;
+
+/// Expiration configuration for an ephemeral Realtime client secret.
+#[derive(Debug, Clone, Ser, De, Default)]
+pub struct ClientSecretExpiration {
+    /// The expiration anchor. Currently this must be `created_at`.
+    #[serde(default = "default_created_at")]
+    pub anchor: String,
+    /// Lifetime in seconds, between 10 and 7200.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub seconds: Option<u64>,
+}
+
+/// Return the only currently supported expiration anchor.
+fn default_created_at() -> String {
+    "created_at".to_owned()
+}
+
+/// Request to create an ephemeral Realtime client secret.
+#[derive(Debug, Clone, Ser, De, Default)]
+pub struct RealtimeClientSecretRequest {
+    /// Optional expiration configuration.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_after: Option<ClientSecretExpiration>,
+    /// Realtime or transcription session configuration.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session: Option<Value>,
+}
+
+impl RealtimeClientSecretRequest {
+    /// Create a request for a session configuration.
+    #[must_use]
+    pub fn new(session: Value) -> Self {
+        Self {
+            expires_after: None,
+            session: Some(session),
+        }
+    }
+
+    /// Set the ephemeral key lifetime in seconds.
+    #[must_use]
+    pub fn with_expiration_seconds(mut self, seconds: u64) -> Self {
+        self.expires_after = Some(ClientSecretExpiration {
+            anchor: default_created_at(),
+            seconds: Some(seconds),
+        });
+        self
+    }
+}
+
+/// Session data returned alongside an ephemeral client secret.
+#[derive(Debug, Clone, Ser, De)]
+pub struct RealtimeClientSecretSession {
+    /// Session discriminator and configuration fields.
+    #[serde(flatten)]
+    pub fields: HashMap<String, Value>,
+}
+
+/// Response from the Realtime client-secret endpoint.
+#[derive(Debug, Clone, Ser, De)]
+pub struct RealtimeClientSecretResponse {
+    /// Ephemeral client secret value.
+    pub value: String,
+    /// Unix expiration timestamp.
+    pub expires_at: u64,
+    /// Session configuration returned by the service.
+    pub session: Value,
+}
+
+/// Current REST request for a transcription session.
+#[derive(Debug, Clone, Ser, De, Default)]
+pub struct RealtimeTranscriptionSessionRequest {
+    /// Server VAD configuration, or null to disable it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub turn_detection: Option<Value>,
+    /// Input audio noise reduction configuration.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_audio_noise_reduction: Option<Value>,
+    /// Audio encoding (`pcm16`, `g711_ulaw`, or `g711_alaw`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_audio_format: Option<String>,
+    /// Optional transcription model/language/prompt configuration.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_audio_transcription: Option<Value>,
+    /// Additional fields to include, such as transcription logprobs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub include: Option<Vec<String>>,
+}
+
+/// Ephemeral secret returned for a transcription session.
+#[derive(Debug, Clone, Ser, De)]
+pub struct RealtimeSessionClientSecret {
+    /// Ephemeral token.
+    pub value: String,
+    /// Unix expiration timestamp.
+    pub expires_at: u64,
+}
+
+/// Response from the transcription-session endpoint.
+#[derive(Debug, Clone, Ser, De, Default)]
+pub struct RealtimeTranscriptionSessionResponse {
+    /// Ephemeral client secret.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_secret: Option<RealtimeSessionClientSecret>,
+    /// Session expiration timestamp.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+    /// Any server fields added over time.
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn client_secret_request_serializes_current_expiration_shape() {
+        let request = RealtimeClientSecretRequest::new(json!({
+            "type": "realtime",
+            "model": "gpt-realtime"
+        }))
+        .with_expiration_seconds(600);
+
+        let value = serde_json::to_value(request).expect("request JSON");
+        assert_eq!(value["expires_after"]["anchor"], "created_at");
+        assert_eq!(value["expires_after"]["seconds"], 600);
+        assert_eq!(value["session"]["model"], "gpt-realtime");
+    }
+}

--- a/src/models/responses_v2.rs
+++ b/src/models/responses_v2.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)]
 
 use crate::models::functions::{Tool, ToolChoice};
-use crate::models::gpt5::{ReasoningConfig, TextConfig};
+use crate::models::gpt5::{PromptCacheOptions, ReasoningConfig, TextConfig};
 use crate::models::responses::message_types::{
     ImageDetail, Message, MessageContent, MessageContentInput, MessageRole,
 };
@@ -83,6 +83,15 @@ pub struct ResponseUsage {
         alias = "completion_tokens_details"
     )]
     pub output_tokens_details: Option<CompletionTokenDetails>,
+}
+
+/// Token count returned by `POST /v1/responses/input_tokens`.
+#[derive(Debug, Clone, Ser, De, Default)]
+pub struct InputTokenCountResponse {
+    /// Resource discriminator (`response.input_tokens`).
+    pub object: String,
+    /// Number of input tokens in the request.
+    pub input_tokens: u32,
 }
 
 /// Detailed prompt token information including caching and audio metrics
@@ -350,6 +359,16 @@ pub enum ServiceTier {
     Priority,
 }
 
+/// Strategy for handling input that exceeds a model's context window.
+#[derive(Debug, Clone, Copy, Ser, De, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Truncation {
+    /// Fail when the context window would be exceeded.
+    Disabled,
+    /// Drop older conversation items to fit the context window.
+    Auto,
+}
+
 /// Streaming options controlling the SSE payload
 #[derive(Debug, Clone, Ser, De, Default)]
 pub struct StreamOptions {
@@ -454,6 +473,15 @@ pub struct CreateResponseRequest {
     /// Prompt cache key for cache-aware routing
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prompt_cache_key: Option<String>,
+    /// Prompt-cache behavior for GPT-5.6 and later.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_cache_options: Option<PromptCacheOptions>,
+    /// Context-window truncation behavior.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub truncation: Option<Truncation>,
+    /// Model-owned style preset.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub personality: Option<String>,
     /// Reasoning configuration for advanced models
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<ReasoningConfig>,
@@ -574,6 +602,13 @@ impl CreateResponseRequest {
         self
     }
 
+    /// Configure streaming event selection, usage, and continuation.
+    #[must_use]
+    pub fn with_stream_options(mut self, options: StreamOptions) -> Self {
+        self.stream_options = Some(options);
+        self
+    }
+
     /// Set the sampling temperature for the response
     #[must_use]
     pub fn with_temperature(mut self, temperature: f32) -> Self {
@@ -655,6 +690,27 @@ impl CreateResponseRequest {
     #[must_use]
     pub fn with_prompt_cache_key(mut self, key: impl Into<String>) -> Self {
         self.prompt_cache_key = Some(key.into());
+        self
+    }
+
+    /// Configure prompt-cache retention and breakpoint behavior.
+    #[must_use]
+    pub fn with_prompt_cache_options(mut self, options: PromptCacheOptions) -> Self {
+        self.prompt_cache_options = Some(options);
+        self
+    }
+
+    /// Set the context-window truncation strategy.
+    #[must_use]
+    pub fn with_truncation(mut self, truncation: Truncation) -> Self {
+        self.truncation = Some(truncation);
+        self
+    }
+
+    /// Set the model-owned personality preset.
+    #[must_use]
+    pub fn with_personality(mut self, personality: impl Into<String>) -> Self {
+        self.personality = Some(personality.into());
         self
     }
 
@@ -898,6 +954,21 @@ impl CreateResponseRequest {
             payload.insert("prompt_cache_key".into(), Value::String(cache_key.clone()));
         }
 
+        if let Some(cache_options) = &self.prompt_cache_options {
+            payload.insert(
+                "prompt_cache_options".into(),
+                serde_json::to_value(cache_options)?,
+            );
+        }
+
+        if let Some(truncation) = &self.truncation {
+            payload.insert("truncation".into(), serde_json::to_value(truncation)?);
+        }
+
+        if let Some(personality) = &self.personality {
+            payload.insert("personality".into(), Value::String(personality.clone()));
+        }
+
         if let Some(reasoning) = &self.reasoning {
             payload.insert("reasoning".into(), serde_json::to_value(reasoning)?);
         }
@@ -1131,6 +1202,15 @@ fn convert_enhanced_request_tool(tool: &EnhancedTool) -> serde_json::Result<Valu
             EnhancedTool::ImageGeneration(_) => ensure_tool_name(map, "image_generation"),
             EnhancedTool::CodeInterpreter(_) => ensure_tool_name(map, "code_interpreter"),
             EnhancedTool::ComputerUse(_) => ensure_tool_name(map, "computer_use"),
+            EnhancedTool::ToolSearch(_) => ensure_tool_name(map, "tool_search"),
+            EnhancedTool::ProgrammaticToolCalling => {
+                ensure_tool_name(map, "programmatic_tool_calling");
+            }
+            EnhancedTool::LocalShell => ensure_tool_name(map, "local_shell"),
+            EnhancedTool::Shell(_) => ensure_tool_name(map, "shell"),
+            EnhancedTool::ApplyPatch(_) => ensure_tool_name(map, "apply_patch"),
+            EnhancedTool::Custom(_) => ensure_tool_name(map, "custom"),
+            EnhancedTool::Namespace(_) => ensure_tool_name(map, "namespace"),
         }
     }
     Ok(value)
@@ -2012,6 +2092,20 @@ pub enum ResponseStreamEvent {
         event_id: Option<String>,
         response: ResponseObject,
     },
+    /// Response accepted and actively processing.
+    #[serde(rename = "response.in_progress")]
+    ResponseInProgress {
+        event_id: Option<String>,
+        response: ResponseObject,
+        sequence_number: Option<u64>,
+    },
+    /// Response queued for processing.
+    #[serde(rename = "response.queued")]
+    ResponseQueued {
+        event_id: Option<String>,
+        response: ResponseObject,
+        sequence_number: Option<u64>,
+    },
     /// Response completed event (final payload)
     #[serde(rename = "response.completed")]
     ResponseCompleted {
@@ -2024,6 +2118,13 @@ pub enum ResponseStreamEvent {
         event_id: Option<String>,
         response: ResponseObject,
     },
+    /// Response ended before completion.
+    #[serde(rename = "response.incomplete")]
+    ResponseIncomplete {
+        event_id: Option<String>,
+        response: ResponseObject,
+        sequence_number: Option<u64>,
+    },
     /// Output item added to the response
     #[serde(rename = "response.output_item.added")]
     OutputItemAdded {
@@ -2031,6 +2132,34 @@ pub enum ResponseStreamEvent {
         response_id: String,
         output_index: u32,
         item: ResponseItem,
+    },
+    /// Output item completed.
+    #[serde(rename = "response.output_item.done")]
+    OutputItemDone {
+        event_id: Option<String>,
+        output_index: u32,
+        item: ResponseItem,
+        sequence_number: Option<u64>,
+    },
+    /// A new content part was added to an output item.
+    #[serde(rename = "response.content_part.added")]
+    ContentPartAdded {
+        event_id: Option<String>,
+        item_id: String,
+        output_index: u32,
+        content_index: u32,
+        part: ContentPart,
+        sequence_number: Option<u64>,
+    },
+    /// An output content part completed.
+    #[serde(rename = "response.content_part.done")]
+    ContentPartDone {
+        event_id: Option<String>,
+        item_id: String,
+        output_index: u32,
+        content_index: u32,
+        part: ContentPart,
+        sequence_number: Option<u64>,
     },
     /// Output text delta received
     #[serde(rename = "response.output_text.delta")]
@@ -2047,6 +2176,124 @@ pub enum ResponseStreamEvent {
         response_id: String,
         output_index: u32,
         text: String,
+    },
+    /// Function-call argument fragment.
+    #[serde(rename = "response.function_call_arguments.delta")]
+    FunctionCallArgumentsDelta {
+        event_id: Option<String>,
+        item_id: String,
+        output_index: u32,
+        delta: String,
+        sequence_number: Option<u64>,
+    },
+    /// Complete function-call arguments.
+    #[serde(rename = "response.function_call_arguments.done")]
+    FunctionCallArgumentsDone {
+        event_id: Option<String>,
+        item_id: String,
+        name: String,
+        output_index: u32,
+        arguments: String,
+        sequence_number: Option<u64>,
+    },
+    /// Custom tool input fragment.
+    #[serde(rename = "response.custom_tool_call_input.delta")]
+    CustomToolCallInputDelta {
+        event_id: Option<String>,
+        item_id: String,
+        output_index: u32,
+        delta: String,
+        sequence_number: Option<u64>,
+    },
+    /// Complete custom tool input.
+    #[serde(rename = "response.custom_tool_call_input.done")]
+    CustomToolCallInputDone {
+        event_id: Option<String>,
+        item_id: String,
+        output_index: u32,
+        input: String,
+        sequence_number: Option<u64>,
+    },
+    /// Reasoning summary text fragment.
+    #[serde(rename = "response.reasoning_summary_text.delta")]
+    ReasoningSummaryTextDelta {
+        event_id: Option<String>,
+        item_id: String,
+        output_index: u32,
+        summary_index: u32,
+        delta: String,
+        sequence_number: Option<u64>,
+    },
+    /// Complete reasoning summary text.
+    #[serde(rename = "response.reasoning_summary_text.done")]
+    ReasoningSummaryTextDone {
+        event_id: Option<String>,
+        item_id: String,
+        output_index: u32,
+        summary_index: u32,
+        text: String,
+        sequence_number: Option<u64>,
+    },
+    /// Reasoning text fragment.
+    #[serde(rename = "response.reasoning_text.delta")]
+    ReasoningTextDelta {
+        event_id: Option<String>,
+        item_id: String,
+        output_index: u32,
+        content_index: u32,
+        delta: String,
+        sequence_number: Option<u64>,
+    },
+    /// Complete reasoning text.
+    #[serde(rename = "response.reasoning_text.done")]
+    ReasoningTextDone {
+        event_id: Option<String>,
+        item_id: String,
+        output_index: u32,
+        content_index: u32,
+        text: String,
+        sequence_number: Option<u64>,
+    },
+    /// Refusal text fragment.
+    #[serde(rename = "response.refusal.delta")]
+    RefusalDelta {
+        event_id: Option<String>,
+        item_id: String,
+        output_index: u32,
+        content_index: u32,
+        delta: String,
+        sequence_number: Option<u64>,
+    },
+    /// Complete refusal text.
+    #[serde(rename = "response.refusal.done")]
+    RefusalDone {
+        event_id: Option<String>,
+        item_id: String,
+        output_index: u32,
+        content_index: u32,
+        refusal: String,
+        sequence_number: Option<u64>,
+    },
+    /// Reasoning summary part was added.
+    #[serde(rename = "response.reasoning_summary_part.added")]
+    ReasoningSummaryPartAdded {
+        event_id: Option<String>,
+        item_id: String,
+        output_index: u32,
+        summary_index: u32,
+        part: Value,
+        sequence_number: Option<u64>,
+    },
+    /// Reasoning summary part completed.
+    #[serde(rename = "response.reasoning_summary_part.done")]
+    ReasoningSummaryPartDone {
+        event_id: Option<String>,
+        item_id: String,
+        output_index: u32,
+        summary_index: u32,
+        part: Value,
+        status: Option<String>,
+        sequence_number: Option<u64>,
     },
     /// Conversation item created/added event
     #[serde(rename = "conversation.item.created")]

--- a/src/models/tools/core_types.rs
+++ b/src/models/tools/core_types.rs
@@ -5,6 +5,89 @@ use super::{
     ImageGenerationConfig, McpTool, WebSearchConfig,
 };
 use crate::{De, Ser};
+use serde_json::Value;
+
+/// Whether tool search is executed by OpenAI or by the client.
+#[derive(Debug, Clone, Copy, Ser, De, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ToolSearchExecution {
+    /// OpenAI performs the tool search.
+    Server,
+    /// The client performs the tool search.
+    Client,
+}
+
+/// Configuration for the hosted/client tool-search capability.
+#[derive(Debug, Clone, Ser, De)]
+pub struct ToolSearchConfig {
+    /// Execution location for tool search.
+    pub execution: ToolSearchExecution,
+    /// Description shown to the model for client execution.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Parameter schema for client-executed searches.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parameters: Option<Value>,
+}
+
+/// Caller context allowed to invoke a callable tool.
+#[derive(Debug, Clone, Copy, Ser, De, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum AllowedToolCaller {
+    /// Direct model invocation.
+    Direct,
+    /// Invocation from programmatic tool calling.
+    Programmatic,
+}
+
+/// Configuration for the shell tool.
+#[derive(Debug, Clone, Ser, De, Default)]
+pub struct ShellToolConfig {
+    /// Container or local execution environment.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub environment: Option<Value>,
+    /// Invocation contexts allowed by the tool.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_callers: Option<Vec<AllowedToolCaller>>,
+}
+
+/// Configuration for the apply-patch tool.
+#[derive(Debug, Clone, Ser, De, Default)]
+pub struct ApplyPatchToolConfig {
+    /// Invocation contexts allowed by the tool.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_callers: Option<Vec<AllowedToolCaller>>,
+}
+
+/// Configuration for a custom text/grammar tool.
+#[derive(Debug, Clone, Ser, De)]
+pub struct CustomToolConfig {
+    /// Name used to identify the custom tool.
+    pub name: String,
+    /// Optional model-facing description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Text or grammar input format.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub format: Option<Value>,
+    /// Whether this tool is discovered through tool search.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub defer_loading: Option<bool>,
+    /// Invocation contexts allowed by the tool.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_callers: Option<Vec<AllowedToolCaller>>,
+}
+
+/// A namespace grouping function or custom tools.
+#[derive(Debug, Clone, Ser, De)]
+pub struct NamespaceToolConfig {
+    /// Namespace used in tool calls.
+    pub name: String,
+    /// Description shown to the model.
+    pub description: String,
+    /// Function/custom tools in this namespace.
+    pub tools: Vec<Value>,
+}
 
 /// Main tool enum representing all available tool types
 #[derive(Debug, Clone, Ser, De)]
@@ -33,4 +116,25 @@ pub enum EnhancedTool {
 
     /// Computer use tool for agentic workflows
     ComputerUse(ComputerUseConfig),
+
+    /// Search deferred tools on the server or client.
+    ToolSearch(ToolSearchConfig),
+
+    /// Allow the model to invoke tools programmatically.
+    ProgrammaticToolCalling,
+
+    /// Execute shell commands in the local environment.
+    LocalShell,
+
+    /// Execute shell commands in a configured environment.
+    Shell(ShellToolConfig),
+
+    /// Create, update, or delete files with unified patches.
+    ApplyPatch(ApplyPatchToolConfig),
+
+    /// A custom text or grammar tool.
+    Custom(CustomToolConfig),
+
+    /// Group function or custom tools under a namespace.
+    Namespace(NamespaceToolConfig),
 }

--- a/src/models/videos.rs
+++ b/src/models/videos.rs
@@ -28,6 +28,10 @@ use crate::{De, Ser};
 #[derive(Debug, Clone, PartialEq, Eq, Ser, De)]
 #[serde(rename_all = "snake_case")]
 pub enum VideoStatus {
+    /// Video generation is queued by the service.
+    Queued,
+    /// Video generation is currently running.
+    InProgress,
     /// Video generation is queued
     Pending,
     /// Video generation is in progress
@@ -64,6 +68,10 @@ pub struct Video {
     /// Current status of the video generation
     pub status: VideoStatus,
 
+    /// Approximate completion percentage for the generation task.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub progress: Option<u32>,
+
     /// The model used to generate the video
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
@@ -84,6 +92,26 @@ pub struct Video {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub height: Option<u32>,
 
+    /// Current API resolution string, such as `1280x720`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size: Option<String>,
+
+    /// Current API duration string, such as `8`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub seconds: Option<String>,
+
+    /// Unix timestamp at which rendering completed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<u64>,
+
+    /// Unix timestamp at which downloadable assets expire.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+
+    /// Source video ID when this job is a remix.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remixed_from_video_id: Option<String>,
+
     /// URL to download the generated video (available when status is completed)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub download_url: Option<String>,
@@ -101,6 +129,18 @@ pub struct CreateVideoRequest {
 
     /// Text prompt describing the desired video
     pub prompt: String,
+
+    /// Current API clip duration (`4`, `8`, or `12`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub seconds: Option<String>,
+
+    /// Current API resolution, for example `720x1280`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size: Option<String>,
+
+    /// Optional image URL or uploaded file reference.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_reference: Option<VideoImageReference>,
 
     /// Desired duration of the video in seconds
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -125,6 +165,9 @@ impl CreateVideoRequest {
         Self {
             model: model.into(),
             prompt: prompt.into(),
+            seconds: None,
+            size: None,
+            input_reference: None,
             duration: None,
             width: None,
             height: None,
@@ -136,6 +179,27 @@ impl CreateVideoRequest {
     #[must_use]
     pub fn with_duration(mut self, duration: f64) -> Self {
         self.duration = Some(duration);
+        self
+    }
+
+    /// Set the current API clip duration.
+    #[must_use]
+    pub fn with_seconds(mut self, seconds: impl Into<String>) -> Self {
+        self.seconds = Some(seconds.into());
+        self
+    }
+
+    /// Set the current API output resolution.
+    #[must_use]
+    pub fn with_size(mut self, size: impl Into<String>) -> Self {
+        self.size = Some(size.into());
+        self
+    }
+
+    /// Set an image URL or uploaded file as a generation reference.
+    #[must_use]
+    pub fn with_input_reference(mut self, input_reference: VideoImageReference) -> Self {
+        self.input_reference = Some(input_reference);
         self
     }
 
@@ -158,6 +222,116 @@ impl CreateVideoRequest {
     pub fn with_n(mut self, n: u32) -> Self {
         self.n = Some(n);
         self
+    }
+}
+
+/// Image URL or uploaded file reference for video generation.
+#[derive(Debug, Clone, Ser, De, Default)]
+pub struct VideoImageReference {
+    /// Fully qualified URL or base64 data URL.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image_url: Option<String>,
+    /// Uploaded file identifier.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file_id: Option<String>,
+}
+
+impl VideoImageReference {
+    /// Reference an image URL.
+    #[must_use]
+    pub fn image_url(url: impl Into<String>) -> Self {
+        Self {
+            image_url: Some(url.into()),
+            file_id: None,
+        }
+    }
+
+    /// Reference an uploaded file.
+    #[must_use]
+    pub fn file_id(file_id: impl Into<String>) -> Self {
+        Self {
+            image_url: None,
+            file_id: Some(file_id.into()),
+        }
+    }
+}
+
+/// Reference to a completed video for edit and extend operations.
+#[derive(Debug, Clone, Ser, De)]
+pub struct VideoReference {
+    /// Completed video identifier.
+    pub id: String,
+}
+
+impl VideoReference {
+    /// Create a video reference.
+    #[must_use]
+    pub fn new(id: impl Into<String>) -> Self {
+        Self { id: id.into() }
+    }
+}
+
+/// JSON request for editing an existing video.
+#[derive(Debug, Clone, Ser, De)]
+pub struct EditVideoRequest {
+    /// Completed source video.
+    pub video: VideoReference,
+    /// Prompt describing the edit.
+    pub prompt: String,
+}
+
+/// JSON request for extending an existing video.
+#[derive(Debug, Clone, Ser, De)]
+pub struct ExtendVideoRequest {
+    /// Completed source video.
+    pub video: VideoReference,
+    /// Prompt describing the extension.
+    pub prompt: String,
+    /// Extension duration in seconds.
+    pub seconds: String,
+}
+
+/// JSON request for remixing an existing video.
+#[derive(Debug, Clone, Ser, De)]
+pub struct RemixVideoRequest {
+    /// Prompt describing the remix.
+    pub prompt: String,
+}
+
+impl EditVideoRequest {
+    /// Create an edit request.
+    #[must_use]
+    pub fn new(video_id: impl Into<String>, prompt: impl Into<String>) -> Self {
+        Self {
+            video: VideoReference::new(video_id),
+            prompt: prompt.into(),
+        }
+    }
+}
+
+impl ExtendVideoRequest {
+    /// Create an extension request.
+    #[must_use]
+    pub fn new(
+        video_id: impl Into<String>,
+        prompt: impl Into<String>,
+        seconds: impl Into<String>,
+    ) -> Self {
+        Self {
+            video: VideoReference::new(video_id),
+            prompt: prompt.into(),
+            seconds: seconds.into(),
+        }
+    }
+}
+
+impl RemixVideoRequest {
+    /// Create a remix request.
+    #[must_use]
+    pub fn new(prompt: impl Into<String>) -> Self {
+        Self {
+            prompt: prompt.into(),
+        }
     }
 }
 
@@ -388,5 +562,61 @@ mod tests {
         assert_eq!(list.object, "list");
         assert!(list.data.is_empty());
         assert!(!list.has_more);
+    }
+
+    #[test]
+    fn current_video_request_and_operation_models() {
+        let request = CreateVideoRequest::new("sora-2", "A fox in snow")
+            .with_seconds("8")
+            .with_size("1280x720")
+            .with_input_reference(VideoImageReference::image_url(
+                "https://example.test/fox.png",
+            ));
+        let request_json = serde_json::to_value(&request).expect("request JSON");
+        assert_eq!(request_json["seconds"], "8");
+        assert_eq!(request_json["size"], "1280x720");
+        assert_eq!(
+            request_json["input_reference"]["image_url"],
+            "https://example.test/fox.png"
+        );
+
+        let file_reference = VideoImageReference::file_id("file_123");
+        assert_eq!(file_reference.file_id.as_deref(), Some("file_123"));
+        assert_eq!(VideoReference::new("video_123").id, "video_123");
+
+        let edit = EditVideoRequest::new("video_123", "Make it brighter");
+        assert_eq!(edit.video.id, "video_123");
+        assert_eq!(edit.prompt, "Make it brighter");
+
+        let extend = ExtendVideoRequest::new("video_123", "Continue the scene", "4");
+        assert_eq!(extend.seconds, "4");
+
+        let remix = RemixVideoRequest::new("Use a watercolor style");
+        assert_eq!(remix.prompt, "Use a watercolor style");
+    }
+
+    #[test]
+    fn current_video_response_fields_round_trip() {
+        let video: Video = serde_json::from_value(serde_json::json!({
+            "id": "video_123",
+            "object": "video",
+            "created_at": 1_800_000_000,
+            "status": "in_progress",
+            "progress": 42,
+            "seconds": "8",
+            "size": "1280x720",
+            "completed_at": null,
+            "expires_at": 1_800_100_000,
+            "remixed_from_video_id": "video_original"
+        }))
+        .expect("video JSON");
+        assert_eq!(video.status, VideoStatus::InProgress);
+        assert_eq!(video.progress, Some(42));
+        assert_eq!(video.seconds.as_deref(), Some("8"));
+        assert_eq!(video.size.as_deref(), Some("1280x720"));
+        assert_eq!(
+            video.remixed_from_video_id.as_deref(),
+            Some("video_original")
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Refresh the SDK to Rust 1.97.1 and current stable direct crate versions, including WebRTC 0.20.
- Add current Responses API controls and endpoints: GPT-5.6 model constants, reasoning mode/summary/context, prompt-cache options, truncation, personality, tool-search/shell/apply-patch/custom/namespace tools, background responses, compaction, input-token counting, and typed reasoning/tool-call stream events.
- Add current Realtime client-secret and transcription-session REST models/endpoints.
- Update the Videos API to current creation payloads and add image references, edit, extend, remix, and binary content downloads while retaining compatibility builders.
- Harden all workflow checkouts with `persist-credentials: false`, preserve explicit release authentication, and refresh the Rust Docker/toolchain versions.
- Preserve deprecated GPT-5 snapshot constants and document the API refresh.

## Validation

- `cargo +1.97.1 fmt --all -- --check`
- `cargo +1.97.1 clippy --all-targets --all-features -- -D warnings`
- `cargo +1.97.1 test --all-features --all-targets` (600 library tests, integration tests, doctests, and examples)
- `make CARGO='cargo +1.97.1' ci` through tests, feature checks, and docs; the wrapper's audit step hit the host's pre-existing non-empty advisory DB directory
- Direct `cargo +1.97.1 audit` and `cargo +1.97.1 deny check` passed; the audit config documents the temporary RUSTSEC-2026-0222 exception because YARA-X 1.19.0 still pins the affected Wasmtime line and no fixed YARA-X release is available yet.
