### PR TITLE
fix: remove unsafe env test mutation and prepare v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [1.6.1] - 2026-08-03
+
+### Security
+
+- Remove test-only process-global unsafe environment mutation by injecting a deterministic
+  environment lookup, preventing parallel tests from racing on OpenAI configuration variables.
+
 ## [1.6.0] - 2026-08-03
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2901,7 +2901,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openai_rust_sdk"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openai_rust_sdk"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2024"
 rust-version = "1.97.1"
 description = "Async, type-safe Rust client for the OpenAI API"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -218,7 +218,7 @@ rather than only when opening the stream.
 
 ## Release source
 
-As of **2026-08-03**, crates.io publishes `openai_rust_sdk` **1.6.0** with
+As of **2026-08-03**, crates.io publishes `openai_rust_sdk` **1.6.1** with
 `rust-version = 1.97.1`. The release tag, packaged crate, and matching docs.rs page
 describe the same source.
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -561,11 +561,18 @@ impl ChatBuilder {
 
 /// Convenience function to create a client from environment variables
 pub fn from_env() -> Result<OpenAIClient> {
-    let api_key = std::env::var("OPENAI_API_KEY").map_err(|_| {
+    from_env_with_lookup(|name| std::env::var(name))
+}
+
+/// Creates a client with an injectable environment lookup for deterministic tests.
+fn from_env_with_lookup(
+    lookup: impl Fn(&str) -> std::result::Result<String, std::env::VarError>,
+) -> Result<OpenAIClient> {
+    let api_key = lookup("OPENAI_API_KEY").map_err(|_| {
         crate::error::OpenAIError::authentication("OPENAI_API_KEY environment variable not set")
     })?;
 
-    let base_url = match std::env::var("OPENAI_BASE_URL") {
+    let base_url = match lookup("OPENAI_BASE_URL") {
         Ok(value) => {
             let trimmed = value.trim();
             if trimmed.is_empty() {
@@ -600,9 +607,6 @@ pub fn from_env_with_base_url(base_url: impl Into<String>) -> Result<OpenAIClien
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
-
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn test_client_creation() {
@@ -645,24 +649,15 @@ mod tests {
 
     #[test]
     fn test_from_env_with_custom_base_url() {
-        let _guard = ENV_LOCK.lock().expect("lock poisoned");
-
-        // SAFETY: ENV_LOCK prevents concurrent environment access in this test module.
-        unsafe {
-            std::env::set_var("OPENAI_API_KEY", "test-key");
-            std::env::set_var("OPENAI_BASE_URL", "https://example-proxy.test/v1");
-        }
-
-        let client = from_env().expect("client creation failed");
+        let client = from_env_with_lookup(|name| match name {
+            "OPENAI_API_KEY" => Ok("test-key".to_string()),
+            "OPENAI_BASE_URL" => Ok("https://example-proxy.test/v1".to_string()),
+            _ => Err(std::env::VarError::NotPresent),
+        })
+        .expect("client creation failed");
         assert_eq!(
             client.responses().base_url(),
             "https://example-proxy.test/v1"
         );
-
-        // SAFETY: ENV_LOCK prevents concurrent environment access in this test module.
-        unsafe {
-            std::env::remove_var("OPENAI_API_KEY");
-            std::env::remove_var("OPENAI_BASE_URL");
-        }
     }
 }


### PR DESCRIPTION
## Summary

- replace the test-only process environment mutation with a private injectable environment lookup
- keep production `from_env()` behavior unchanged by delegating to `std::env::var`
- remove the module-local mutex and all unsafe environment operations
- bump the crate and lockfile to 1.6.1 with a dated security changelog entry and current-version docs

## Root cause

The post-merge push security scan [run 30829977018](https://github.com/ThreatFlux/openai_rust_sdk/actions/runs/30829977018) correctly flagged two `unsafe-usage` findings. In Rust 2024, environment mutation is unsafe because other threads may read the process environment; the test mutex only serialized this module and could not provide a process-wide guarantee.

## Validation

- targeted client environment test passes
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- Semgrep `p/security-audit p/secrets p/rust`: 0 findings
- `cargo publish --dry-run --locked --all-features --allow-dirty`
- `python3 scripts/check_package.py`
- `cargo fmt --all -- --check`
- `git diff --check`

## Release

The immutable `v1.6.0` tag remains at its original release merge and will not be moved or yanked. Once this PR is green and merged, its exact squash-merge commit will receive a new annotated `v1.6.1` tag.