### PR TITLE
ci: adopt ThreatFlux auto-release action

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,141 +1,126 @@
 name: Auto Release
 
+concurrency:
+  group: auto-release-${{ github.event.workflow_run.head_branch || github.ref_name || 'main' }}
+  cancel-in-progress: true
+
 on:
+  workflow_run:
+    workflows: ["CI", "Security"]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - 'Cargo.toml'
+    inputs:
+      version_bump:
+        description: Version bump type
+        required: true
+        default: auto
+        type: choice
+        options:
+          - auto
+          - patch
+          - minor
+          - major
 
 permissions:
   contents: read
 
-concurrency:
-  group: auto-release-${{ github.ref }}
-  cancel-in-progress: false
-
-env:
-  CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.97.1
-
 jobs:
-  check-version:
-    name: Check Version
+  check:
+    name: Check for Release
     runs-on: ubuntu-latest
+    if: >-
+      (github.event_name == 'workflow_run' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name == github.repository) ||
+      github.event_name == 'workflow_dispatch'
+    permissions:
+      actions: read
+      contents: read
     outputs:
-      version_changed: ${{ steps.version.outputs.changed }}
-      new_version: ${{ steps.version.outputs.version }}
+      should_release: ${{ steps.decide.outputs.should_release }}
+      target_sha: ${{ steps.target.outputs.sha }}
     steps:
-      - name: Checkout sources
+      - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
           persist-credentials: false
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref_name }}
 
-      - name: Verify release source
-        shell: bash
+      - name: Determine target SHA
+        id: target
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
-            echo "Auto Release must run from main, got $GITHUB_REF" >&2
-            exit 1
-          fi
-          git fetch --no-tags origin main
-          if [[ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]]; then
-            echo "The selected commit is no longer the tip of origin/main" >&2
-            exit 1
-          fi
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # v1
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
-
-      - name: Check release version
-        id: version
-        shell: bash
-        run: |
-          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
-          TAG="v${VERSION}"
-          git check-ref-format "refs/tags/$TAG"
-          if ! grep -Fq "## [$VERSION] -" CHANGELOG.md; then
-            echo "CHANGELOG.md does not contain a dated $VERSION release entry" >&2
-            exit 1
-          fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
-            echo "$TAG already exists; no release needed"
-            echo "changed=false" >> "$GITHUB_OUTPUT"
+          if [[ "${EVENT_NAME}" == "workflow_run" ]]; then
+            if [[ ! "${WORKFLOW_RUN_HEAD_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "Invalid workflow-run head SHA" >&2
+              exit 1
+            fi
+            echo "sha=${WORKFLOW_RUN_HEAD_SHA}" >> "$GITHUB_OUTPUT"
           else
-            echo "New release version: $TAG"
-            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           fi
 
-  verify-package:
-    name: Verify Package
-    needs: check-version
-    if: needs.check-version.outputs.version_changed == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
+      - name: Check CI status
+        id: ci_status
+        run: |
+          TARGET_SHA="${{ steps.target.outputs.sha }}"
+          CI_STATUS=$(gh run list --workflow=ci.yml --branch=main --commit="$TARGET_SHA" --event=push --limit=1 --json conclusion --jq '.[0].conclusion // ""')
+          SECURITY_STATUS=$(gh run list --workflow=security.yml --branch=main --commit="$TARGET_SHA" --event=push --limit=1 --json conclusion --jq '.[0].conclusion // ""')
+          if [[ "$CI_STATUS" == "success" ]] && [[ "$SECURITY_STATUS" == "success" ]]; then
+            echo "all_passed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "all_passed=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # v1
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
+      - name: Decide whether to attempt a release
+        id: decide
+        env:
+          ALL_PASSED: ${{ steps.ci_status.outputs.all_passed }}
+        run: |
+          # The release action itself no-ops when no conventional commit
+          # warrants a release, so this gate only enforces green required runs.
+          if [[ "${ALL_PASSED}" == "true" ]]; then
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Run tests
-        run: cargo test --all-features --locked
-
-      - name: Verify package contents
-        run: python3 scripts/check_package.py
-
-      - name: Verify crate package
-        run: cargo package --all-features --locked
-
-  create-release:
-    name: Create Annotated Tag
-    needs: [check-version, verify-package]
-    if: needs.check-version.outputs.version_changed == 'true'
+  release:
+    name: Create Release
+    needs: check
+    if: needs.check.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     permissions:
-      actions: write
       contents: write
+      actions: write
     steps:
-      - name: Checkout sources
+      - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ needs.check.outputs.target_sha }}
 
-      - name: Create immutable annotated tag
+      - name: Release
+        id: release
+        uses: ThreatFlux/github_actions/release@16d779cd569c34743eb6683ca4c0ce105e9ad234 # v0.4.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          bump: ${{ github.event.inputs.version_bump || 'auto' }}
+
+      # Tags created with GITHUB_TOKEN do not trigger tag-push workflows, so
+      # dispatch the tag pipelines explicitly.
+      - name: Trigger tag pipelines
+        if: steps.release.outputs.released == 'true'
         env:
-          RELEASE_VERSION: ${{ needs.check-version.outputs.new_version }}
-        shell: bash
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.release.outputs.version }}
+          TAG: ${{ steps.release.outputs.tag }}
         run: |
-          git fetch --no-tags origin main
-          if [[ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]]; then
-            echo "main advanced after package verification; restart the release" >&2
-            exit 1
-          fi
-          TAG="v${RELEASE_VERSION}"
-          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
-            echo "$TAG already exists; refusing to move it" >&2
-            exit 1
-          fi
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git tag -a "$TAG" -m "Release $TAG"
-          git push origin "$TAG"
-
-      - name: Dispatch release workflow
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_VERSION: ${{ needs.check-version.outputs.new_version }}
-        shell: bash
-        run: >-
-          gh workflow run release.yml
-          --ref "v${RELEASE_VERSION}"
-          --field "version=${RELEASE_VERSION}"
+          gh workflow run release.yml --repo "$GITHUB_REPOSITORY" --ref "$TAG" -f version="$VERSION"
+          gh workflow run docker.yml --repo "$GITHUB_REPOSITORY" --ref "$TAG"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -347,7 +347,7 @@ jobs:
     name: Sign Container
     needs: [build, scan, test]
     runs-on: ${{ vars.RUST_TEMPLATE_RUNNER_UBUNTU || 'ubuntu-latest' }}
-    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Adopts the ThreatFlux auto-release action for this repo, replacing the previous Cargo.toml-diff-based auto-release workflow.

## What the action does

`ThreatFlux/github_actions/release` (SHA-pinned to `16d779cd…`, i.e. **v0.4.2**) inspects the conventional-commit history since the last tag, decides the semver bump (`feat:` = minor, `fix:` = patch, `!`/`BREAKING CHANGE` = major), rewrites `Cargo.toml` and `Cargo.lock` with the new version, creates the tag, and publishes the GitHub Release — all through the GitHub API, with no git or cargo invocations at runtime. Merges that contain only `chore:`/`docs:`/`ci:` commits produce **no release** (the action no-ops). This PR itself uses a `ci:` subject for that reason.

## Gating

The workflow runs on `workflow_run` completion of **CI** and **Security** on `main` (plus manual `workflow_dispatch` with a bump-type override). Before releasing, it re-checks via `gh run list` that the push-triggered CI **and** Security runs for the exact target SHA both concluded `success`, so a release only happens when both pipelines are green for that commit.

## Tag-trigger limitation and dispatch chaining

Tags created with `GITHUB_TOKEN` do not fire tag-push (`on: push: tags:`) workflows. To compensate, after a successful release the workflow explicitly dispatches:

- `release.yml` at the new tag with `-f version=<version>` (its `workflow_dispatch` accepts a `version` input), and
- `docker.yml` at the new tag (it has a plain `workflow_dispatch` trigger).

## Bug fixes applied

- **docker.yml**: the cosign `sign` job was gated `github.ref == 'refs/heads/main'`, so tag builds were never signed. Extended to `(github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))`.

The other template bugs from the rollout checklist (missing `shell: bash` on a native-build step, an indented heredoc terminator in the crates.io publish check, and a Windows package step that never wrote its `.sha256`) **do not exist in this repo** — `release.yml` here is Linux-only and every bash step already declares `shell: bash` — so no changes were needed there.

## Behavior removed from the old auto-release.yml

The replaced workflow did more than bump/tag/release; the following behaviors are gone from the auto-release path (though most still run inside the dispatched `release.yml`):

- Required a dated `## [x.y.z] -` entry in `CHANGELOG.md` before tagging.
- Ran `cargo test`, `scripts/check_package.py`, and `cargo package` as a pre-tag verification job.
- Created an **annotated** tag via `git tag -a`; the action creates the tag through the API instead.

## Caveats worth knowing before merging

- `release.yml`'s "Verify release version" step fails if `CHANGELOG.md` lacks a dated entry for the released version. The action does **not** edit changelogs, so the dispatched `release.yml` run (and the crates.io publish it performs) will fail unless the changelog entry for the upcoming version is landed before the releasing merge.
- `release.yml`'s "Verify release provenance" step requires the tag to be an **annotated** tag object (`git cat-file -t == "tag"`). If the action creates a lightweight tag via the API, that check will reject it; the check may need loosening in a follow-up if dispatched runs fail there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
